### PR TITLE
Leave external URLs in CSS alone

### DIFF
--- a/src/optimus/assets.clj
+++ b/src/optimus/assets.clj
@@ -59,7 +59,7 @@
   (.startsWith url "data:"))
 
 (defn- external-url? [#^String url]
-  (.startsWith url "//"))
+  (re-matches #"^(?://|http://|https://).*" url))
 
 (defn- replace-css-urls [file replacement-fn]
   (assoc-in file [:contents]

--- a/test/optimus/assets_test.clj
+++ b/test/optimus/assets_test.clj
@@ -93,13 +93,21 @@
                                                :contents "#id { background: url(data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==)}"
                                                :references #{}}]))
 
-(with-files [["/main.css" "#id { background: url(//some.site/img.png)}"]]
+(with-files [["/main1.css" "#id { background: url(//some.site/img.png)}"]
+             ["/main2.css" "#id { background: url(http://some.site/img.png)}"]
+             ["/main3.css" "#id { background: url(https://some.site/img.png)}"]]
   (fact
    "External URLs are left alone."
 
-   (load-assets public-dir ["/main.css"]) => [{:path "/main.css"
-                                               :contents "#id { background: url(//some.site/img.png)}"
-                                               :references #{}}]))
+   (load-assets public-dir ["/main1.css" "/main2.css" "/main3.css"]) => [{:path "/main1.css"
+                                                                          :contents "#id { background: url(//some.site/img.png)}"
+                                                                          :references #{}}
+                                                                         {:path "/main2.css"
+                                                                          :contents "#id { background: url(http://some.site/img.png)}"
+                                                                          :references #{}}
+                                                                         {:path "/main3.css"
+                                                                          :contents "#id { background: url(https://some.site/img.png)}"
+                                                                          :references #{}}]))
 
 (with-files [["/main.css" "#id { background: url('/bg.png'); }"]]
   (fact


### PR DESCRIPTION
Only checks for initial double slash (//), should add http/https as well?
