### PR TITLE
Access assets using 'clojure.java.io/resource'

### DIFF
--- a/src/optimus/assets.clj
+++ b/src/optimus/assets.clj
@@ -2,9 +2,9 @@
   (:require [optimus.assets.creation :refer [load-asset]]
             [optimus.assets.load-css]))
 
-(defmethod load-asset "js"   [public-dir path] (optimus.assets.creation/load-text-asset public-dir path))
-(defmethod load-asset "html" [public-dir path] (optimus.assets.creation/load-text-asset public-dir path))
-(defmethod load-asset "css"  [public-dir path] (optimus.assets.load-css/load-css-asset public-dir path))
+(defmethod load-asset "js"   [public-dir path resource] (optimus.assets.creation/load-text-asset public-dir path resource))
+(defmethod load-asset "html" [public-dir path resource] (optimus.assets.creation/load-text-asset public-dir path resource))
+(defmethod load-asset "css"  [public-dir path resource] (optimus.assets.load-css/load-css-asset public-dir path resource))
 
 (def create-asset optimus.assets.creation/create-asset)
 (def load-assets optimus.assets.creation/load-assets)

--- a/src/optimus/assets/load_css.clj
+++ b/src/optimus/assets/load_css.clj
@@ -50,6 +50,5 @@
       (make-css-urls-absolute)
       (update-css-references)))
 
-(defn load-css-asset [public-dir path]
-  (let [resource (existing-resource public-dir path)]
-    (create-css-asset path (slurp resource) (last-modified resource))))
+(defn load-css-asset [public-dir path resource]
+  (create-css-asset path (slurp resource) (last-modified resource)))

--- a/src/optimus/class_path.clj
+++ b/src/optimus/class_path.clj
@@ -1,37 +1,98 @@
 (ns optimus.class-path
-  (:require [clojure.string :as s])
+  (:require [clojure.string :as s]
+            [clojure.java.io :as io])
   (:import [java.io File]
+           [java.net URL URI]
            [java.util.zip ZipFile ZipEntry]))
 
-(defn class-path-elements []
-  (->> (s/split (System/getProperty "java.class.path" ".") #":")
-       (remove (fn [#^String s] (.contains s "/.m2/")))))
 ;; there are major performance improvements to be gained by not
 ;; traversing the entirety of the class path when running locally and
 ;; picking up files from the class path for every request. Since
 ;; you're not serving files from a .m2 folder in production, this is
 ;; hopefully a safe bet.
 
-(defn get-file-paths [#^File file]
-  (if (.isDirectory file)
-    (mapcat get-file-paths (.listFiles file))
-    [(.getCanonicalPath file)]))
+(defn- ->url
+  [^File f]
+  (vector
+    (.getCanonicalPath f)
+    (-> f (.toURI) (.toURL))))
 
-(defn get-jar-paths [jar]
-  (->> jar
-       (java.util.zip.ZipFile.)
+(defn- ->jar-url
+  [^URL jar ^String path]
+  (let [uri (URI. (str "jar:" (.toURI jar) "!" path))]
+    (vector
+      (or (.getPath uri) path)
+      (.toURL uri))))
+
+(defn- parse-jar-url
+  [^URL url]
+  (let [^String p (.getPath url)
+        idx (.lastIndexOf p "!")]
+    (vector
+      (URL. (if (neg? idx) p (subs p 0 idx)))
+      (when-not (neg? idx)
+        (subs p (inc idx))))))
+
+(defn- jar-contents
+  [^File jar-file]
+  (->> (ZipFile. jar-file)
        (.entries)
        (enumeration-seq)
-       (map (fn [#^ZipEntry e] (.getName e)))))
+       (map #(str "/" (.getName ^ZipEntry %)))
+       (remove #(.endsWith ^String % "/"))
+       (vec)))
 
-(defn get-resource-paths [path]
-  (let [path-plus-slash-length (inc (count path))
-        chop-path #(subs % path-plus-slash-length)
-        file (File. path)]
-    (cond
-     (.isDirectory file) (get-file-paths file)
-     (.exists file) (get-jar-paths file)
-     :else [])))
+(defn- list-jar-contents
+  [^URL url]
+  (let [[jar path] (parse-jar-url url)
+        jar-file (io/file jar)]
+    (when (.isFile jar-file)
+      (let [contents (jar-contents jar-file)]
+        (->> (if path
+               (filter #(.startsWith ^String % path) contents)
+               contents)
+             (map #(->jar-url jar %)))))))
 
-(defn file-paths-on-class-path []
-  (mapcat get-resource-paths (class-path-elements)))
+(defn- list-files
+  [^File f]
+  (when (.exists f)
+    (letfn [(lazy-traverse [^File dir]
+              (lazy-seq
+                (let [fs (.listFiles dir)]
+                  (mapcat
+                    (fn [^File f]
+                      (if (.isDirectory f)
+                        (lazy-traverse f)
+                        [(->url f)]))
+                    fs))))]
+      (if (.isDirectory f)
+        (lazy-traverse f)
+        [(->url f)]))))
+
+(defn- resources
+  [directory-path]
+  (-> (Thread/currentThread)
+      (.getContextClassLoader)
+      (.getResources directory-path)
+      (enumeration-seq)))
+
+(defn resource-urls
+  "Find all files residing in a directory of the given name within _all of the classpath_.
+   Apply the given function to the path string and produce either the path string to use
+   or nil.
+
+   Returns a map of `[path-string -> URL]`."
+  [directory-path path-fn]
+  (let [^File f (io/file directory-path)
+        files (list-files f)]
+    (->> (for [^URL url (resources directory-path)]
+           (case (.getProtocol url)
+             "jar"  (list-jar-contents url)
+             "file" (list-files (io/file url))
+             nil))
+         (apply concat files)
+         (keep
+           (fn [[path url]]
+             (when-let [path' (path-fn path)]
+               [path' url])))
+         (into {}))))


### PR DESCRIPTION
Instead of listing all the files in all the JARs on the classpath (with exception of `~/.m2/...` which, btw, makes testing assets in such JARs on the REPL impossible), this PR finds the desired directory (either on the filesystem or within a JAR) and creates the file list in a more targeted manner.

I hope you can use this but I might be overlooking some use case where this approach breaks things. 

Tests are passing.
