### PR TITLE
Fix TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: clojure
 lein: lein2
-script: lein2 test
+script: lein2 midje
 jdk:
   - openjdk6
   - openjdk7


### PR DESCRIPTION
Currently, the command `lein test` is run on TravisCI, ignoring all the Midje facts. This PR fixes that.
