### PR TITLE
Bump version of clj-time to play nice with Ring usage of newer API

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [org.clojure/core.memoize "0.5.6"]
                  [org.clojure/data.codec "0.1.0"]
                  [pathetic "0.5.1"]
-                 [clj-time "0.5.1"]
+                 [clj-time "0.6.0"]
                  [clj-v8 "0.1.5"]]
   :profiles {:dev {:dependencies [[midje "1.6.0"]
                                   [optimus-test-jar "0.1.0"]


### PR DESCRIPTION
Earlier this month, Ring updated its dependency on clj-time to 0.6.0, and switched to using new API functions, particularly `in-seconds` for cookies. https://github.com/ring-clojure/ring/commit/7d618a9d4e0ff0cf0368cd159f9b786e904332d2

Optimus depends on clj-time 0.5.1, which seems to be what gets resolved and used, so Ring's reference to `in-seconds` fails with a fatal IllegalAccessException.

The PR bumps Optimus's dependency on clj-time to 0.6.0 too. (It might even be safe to use 0.7.0 which removes deprecated functions, as Optimus doesn't seem to use any of them.) All unit tests pass and I can't find any likely breakages with the change.

A workaround for anyone else having this problem is to just depend on clj-time 0.6.0 explicitly in your own project.clj.
