### PR TITLE
Add :bundle-url-prefix config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,21 +255,6 @@ Adding your own asset transformation functions is fair game too. In
 fact, it's encouraged. Let's say you need to serve all assets from a
 Content Delivery Network ...
 
-#### Serving bundles under a custom URL prefix
-
-`optimizations/concatenate-bundles` generates a bundled asset with the
-`"/bundle"` prefix. If you need to serve assets with a different prefix, provide
-the `:bundle-url-prefix` config option to either `optimizations/all` or
-`optimizations/concatenate-bundles`:
-
-```cl
-(-> app
-    (optimus/wrap
-     get-assets
-     (optimizations/all {:bundle-url-prefix "/assets/bundles"})
-     the-strategy))
-```
-
 #### Yeah, we are using a Content Delivery Network. How does that work?
 
 To serve the files from a different host, add a `:base-url` to the assets:
@@ -323,6 +308,21 @@ Like this:
         (remove :bundled assets)
         (remove :outdated assets)
         (optimus.export/save-assets assets "./cdn-export/")))
+```
+
+#### Serving bundles under a custom URL prefix
+
+`optimizations/concatenate-bundles` generates a bundled asset with the
+`"/bundle"` prefix. If you need to serve assets with a different prefix, provide
+the `:bundle-url-prefix` config option to either `optimizations/all` or
+`optimizations/concatenate-bundles`:
+
+```cl
+(-> app
+    (optimus/wrap
+     get-assets
+     (optimizations/all {:bundle-url-prefix "/assets/bundles"})
+     the-strategy))
 ```
 
 ## So how does all this work in development mode?

--- a/README.md
+++ b/README.md
@@ -255,6 +255,21 @@ Adding your own asset transformation functions is fair game too. In
 fact, it's encouraged. Let's say you need to serve all assets from a
 Content Delivery Network ...
 
+#### Serving bundles under a custom URL prefix
+
+`optimizations/concatenate-bundles` generates a bundled asset with the
+`"/bundle"` prefix. If you need to serve assets with a different prefix, provide
+the `:bundle-url-prefix` config option to either `optimizations/all` or
+`optimizations/concatenate-bundles`:
+
+```cl
+(-> app
+    (optimus/wrap
+     get-assets
+     (optimizations/all {:bundle-url-prefix "/assets/bundles"})
+     the-strategy))
+```
+
 #### Yeah, we are using a Content Delivery Network. How does that work?
 
 To serve the files from a different host, add a `:base-url` to the assets:

--- a/src/optimus/optimizations.clj
+++ b/src/optimus/optimizations.clj
@@ -23,7 +23,7 @@
       (minify-js-assets options)
       (minify-css-assets options)
       (inline-css-imports)
-      (concatenate-bundles)
+      (concatenate-bundles options)
       (add-cache-busted-expires-headers)
       (add-last-modified-headers)))
 

--- a/src/optimus/optimizations/concatenate_bundles.clj
+++ b/src/optimus/optimizations/concatenate_bundles.clj
@@ -3,9 +3,9 @@
             [clojure.string :as str]
             [optimus.homeless :refer [assoc-non-nil max?]]))
 
-(defn- concatenate-bundle [[name assets]]
+(defn- concatenate-bundle [prefix [name assets]]
   (when name
-    (-> {:path (str "/bundles/" name)
+    (-> {:path (str prefix "/" name)
          :contents (str/join "\n" (map :contents assets))
          :bundle name}
         (assoc-non-nil :references (apply union (map :references assets)))
@@ -18,6 +18,9 @@
         (assoc :bundled true))
     asset))
 
-(defn concatenate-bundles [assets]
-  (concat (map mark-as-bundled assets)
-          (keep concatenate-bundle (group-by :bundle assets))))
+(defn concatenate-bundles
+  ([assets] (concatenate-bundles assets {}))
+  ([assets config]
+   (let [prefix (or (:bundle-url-prefix config) "/bundles")]
+     (concat (map mark-as-bundled assets)
+             (keep #(concatenate-bundle prefix %) (group-by :bundle assets))))))

--- a/test/optimus/optimizations/concatenate_bundles_test.clj
+++ b/test/optimus/optimizations/concatenate_bundles_test.clj
@@ -1,6 +1,6 @@
 (ns optimus.optimizations.concatenate-bundles-test
-  (:use [optimus.optimizations.concatenate-bundles]
-        [midje.sweet]))
+  (:use [midje.sweet]
+        [optimus.optimizations.concatenate-bundles]))
 
 (fact
  "When files are bundled together, we still keep the original ones.
@@ -46,3 +46,12 @@
      ["/more.css" 2]
      ["/gone.css" nil]
      ["/bundles/styles.css" 2]])
+
+(fact
+ "Bundle files under a custom URL prefix"
+
+ (->> (concatenate-bundles [{:path "/main.css" :contents "" :bundle "styles.css"}]
+                           {:bundle-url-prefix "/assets"})
+      (map :path))
+ => ["/main.css"
+     "/assets/styles.css"])

--- a/test/optimus/optimizations_test.clj
+++ b/test/optimus/optimizations_test.clj
@@ -1,8 +1,8 @@
 (ns optimus.optimizations-test
-  (:require [optimus.optimizations :as optimizations]
+  (:require [clj-time.core :as time]
             [optimus.assets]
-            [test-with-files.core :refer [with-files public-dir]]
-            [clj-time.core :as time])
+            [optimus.optimizations :as optimizations]
+            [test-with-files.core :refer [with-files public-dir]])
   (:use midje.sweet))
 
 (with-redefs [time/now (fn [] (time/date-time 2013 07 30))]
@@ -44,3 +44,14 @@
        (optimus.assets/load-assets "public" ["/encoding.js"]))
       (map (juxt :path :contents)))
  => [["/encoding.js" "var s=\"Klaida inicijuojant pasirašymą!\";"]])
+
+(fact
+ "It allows configuring the concat bundle prefix"
+ (->> (optimizations/all
+       [{:path "/core.js" :contents "var x = 1 + 2;" :bundle "app.js"}]
+       {:bundle-url-prefix "/assets/bundles"})
+      (map :path))
+ => ["/core.js"
+     "/assets/bundles/app.js"
+     "/1e10b6b7ffe7/core.js"
+     "/assets/bundles/1e10b6b7ffe7/app.js"])


### PR DESCRIPTION
Makes it possible to override the hard-coded `/bundles` URL path for concatenated bundles. It is quite possible to achieve the same thing now by simply changing the `:path` of the resulting asset, but it would be convenient to have Optimus generate the desired URL directly.