### PR TITLE
Add :context-path option to assets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: clojure
-lein: lein2
-script: lein2 midje
+lein: lein
+script: lein midje
 jdk:
   - openjdk7
   - oraclejdk7

--- a/README.md
+++ b/README.md
@@ -255,21 +255,6 @@ Adding your own asset transformation functions is fair game too. In
 fact, it's encouraged. Let's say you need to serve all assets from a
 Content Delivery Network ...
 
-#### Serving bundles under a custom URL prefix
-
-`optimizations/concatenate-bundles` generates a bundled asset with the
-`"/bundle"` prefix. If you need to serve assets with a different prefix, provide
-the `:bundle-url-prefix` config option to either `optimizations/all` or
-`optimizations/concatenate-bundles`:
-
-```cl
-(-> app
-    (optimus/wrap
-     get-assets
-     (optimizations/all {:bundle-url-prefix "/assets/bundles"})
-     the-strategy))
-```
-
 #### Yeah, we are using a Content Delivery Network. How does that work?
 
 To serve the files from a different host, add a `:base-url` to the assets:

--- a/README.md
+++ b/README.md
@@ -288,6 +288,29 @@ You can even add an alias to your `project.clj`:
 
 And run `lein export-assets` from the command line. Handy.
 
+#### Hey, I'm serving my app from a sub-directory, how can I avoid referencing it everywhere?
+
+Locally, your app is known as `http://localhost:3000/`, but in production it
+will share the limelight with others like it, so it'll go live at
+`http://limelight.com/app/`. Wouldn't it be nice if you could do that without
+adding the extra folder and referencing it everywhere? Well, now you can!
+
+To serve the files from a directory/context path add a `:context-path` to the
+assets:
+
+```cl
+(defn add-context-path-to-assets [assets]
+  (map #(assoc % :context-path "/myapp/") assets))
+
+(defn my-optimize [assets options]
+  (-> assets
+      (optimizations/all options)
+      (add-context-path-to-assets)))
+```
+
+Now your links to your assets (including those in CSS files) will reference
+assets with the context path + the file path.
+
 #### Those are a whole lot of files being exported.
 
 Yeah, two reasons for that:
@@ -670,6 +693,7 @@ you might want to [read more about them](breaking-changes.md).
   using it at the same time.
 - Fixed an issue with files referenced in CSS files when using `:base-url`. (Luke Snape)
 - Added support for custom `:bundle-url-prefix`
+- Added support for `:context-path` per asset
 
 #### From 0.18.5 to 0.19
 

--- a/README.md
+++ b/README.md
@@ -255,6 +255,21 @@ Adding your own asset transformation functions is fair game too. In
 fact, it's encouraged. Let's say you need to serve all assets from a
 Content Delivery Network ...
 
+#### Serving bundles under a custom URL prefix
+
+`optimizations/concatenate-bundles` generates a bundled asset with the
+`"/bundle"` prefix. If you need to serve assets with a different prefix, provide
+the `:bundle-url-prefix` config option to either `optimizations/all` or
+`optimizations/concatenate-bundles`:
+
+```cl
+(-> app
+    (optimus/wrap
+     get-assets
+     (optimizations/all {:bundle-url-prefix "/assets/bundles"})
+     the-strategy))
+```
+
 #### Yeah, we are using a Content Delivery Network. How does that work?
 
 To serve the files from a different host, add a `:base-url` to the assets:

--- a/README.md
+++ b/README.md
@@ -669,6 +669,7 @@ you might want to [read more about them](breaking-changes.md).
 - Use a fixed version of clj-v8 that does not crash when starting two processes
   using it at the same time.
 - Fixed an issue with files referenced in CSS files when using `:base-url`. (Luke Snape)
+- Added support for custom `:bundle-url-prefix`
 
 #### From 0.18.5 to 0.19
 

--- a/src/optimus/link.clj
+++ b/src/optimus/link.clj
@@ -1,10 +1,8 @@
 (ns optimus.link
   (:require [optimus.assets :as assets]))
 
-(defn full-path [asset]
-  (if-let [base (:base-url asset)]
-    (str base (:path asset))
-    (:path asset)))
+(defn full-path [{:keys [base-url context-path path]}]
+  (str base-url context-path path))
 
 (defn file-path [request path & {:as options}]
   (let [path (->> request :optimus-assets

--- a/src/optimus/optimizations/concatenate_bundles.clj
+++ b/src/optimus/optimizations/concatenate_bundles.clj
@@ -3,7 +3,17 @@
             [clojure.string :as str]
             [optimus.homeless :refer [assoc-non-nil max?]]))
 
+(defn- verify-unique-qualifiers [assets qualifier]
+  (let [xs (into #{} (map qualifier assets))]
+    (when (< 1 (count xs))
+      (throw (ex-info (format "Cannot bundle assets with different %ss: %s"
+                              (name qualifier)
+                              (str/join " " (map #(if (nil? %) "nil" (str "\"" % "\"")) (sort xs))))
+                      {:assets assets})))))
+
 (defn- concatenate-bundle [prefix [name assets]]
+  (verify-unique-qualifiers assets :context-path)
+  (verify-unique-qualifiers assets :base-url)
   (when name
     (-> {:path (str prefix "/" name)
          :contents (str/join "\n" (map :contents assets))

--- a/src/optimus/optimizations/concatenate_bundles.clj
+++ b/src/optimus/optimizations/concatenate_bundles.clj
@@ -18,6 +18,8 @@
     (-> {:path (str prefix "/" name)
          :contents (str/join "\n" (map :contents assets))
          :bundle name}
+        (assoc-non-nil :context-path (-> assets first :context-path))
+        (assoc-non-nil :base-url (-> assets first :base-url))
         (assoc-non-nil :references (apply union (map :references assets)))
         (assoc-non-nil :last-modified (max? (keep :last-modified assets))))))
 

--- a/src/optimus/strategies.clj
+++ b/src/optimus/strategies.clj
@@ -27,6 +27,9 @@
          (map pb->assets)
          (map #(reduce collapse-equal-assets %)))))
 
+(defn- asset-path [{:keys [context-path path]}]
+  (str context-path path))
+
 (defn serve-live-assets [app get-assets optimize options]
   (let [get-optimized-assets #(optimize (guard-against-duplicate-assets (get-assets)) options)
         get-optimized-assets (if-let [ms (get options :cache-live-assets 2000)]
@@ -34,7 +37,7 @@
                                get-optimized-assets)]
     (fn [request]
       (let [assets (get-optimized-assets)
-            path->asset (into {} (map (juxt :path identity) assets))]
+            path->asset (into {} (map (juxt asset-path identity) assets))]
         (serve-asset-or-continue assets path->asset app request)))))
 
 (defn serve-live-assets-autorefresh [app get-assets optimize options]
@@ -47,11 +50,11 @@
     (watch-dir on-assets-changed assets-dir)
     (fn [request]
       (let [assets @assets-cache
-            path->asset (into {} (map (juxt :path identity) assets))]
+            path->asset (into {} (map (juxt asset-path identity) assets))]
         (serve-asset-or-continue assets path->asset app request)))))
 
 (defn serve-frozen-assets [app get-assets optimize options]
   (let [assets (optimize (guard-against-duplicate-assets (get-assets)) options)
-        path->asset (into {} (map (juxt :path identity) assets))]
+        path->asset (into {} (map (juxt asset-path identity) assets))]
     (fn [request]
       (serve-asset-or-continue assets path->asset app request))))

--- a/test/optimus/link_test.clj
+++ b/test/optimus/link_test.clj
@@ -1,6 +1,6 @@
 (ns optimus.link-test
-  (:use [optimus.link]
-        [midje.sweet]))
+  (:use [midje.sweet]
+        [optimus.link]))
 
 (fact
  "You can link to a specific file by its original path. Outdated files
@@ -52,3 +52,25 @@
 
    (file-path request "/main.js") => "http://cache.example.com/main.js"
    (bundle-paths request ["app.js"]) => ["http://cache.example.com/main.js"]))
+
+(fact
+ "You can link to assets that are served from a web server directory,
+  by setting the :context-path property."
+
+ (let [request {:optimus-assets [{:path "/main.js"
+                                  :context-path "/somewhere"
+                                  :bundle "app.js"}]}]
+
+   (file-path request "/main.js") => "/somewhere/main.js"
+   (bundle-paths request ["app.js"]) => ["/somewhere/main.js"]))
+
+(fact
+ "You can combine the :base-url and :context-path properties."
+
+ (let [request {:optimus-assets [{:path "/main.js"
+                                  :base-url "http://example.com"
+                                  :context-path "/somewhere"
+                                  :bundle "app.js"}]}]
+
+   (file-path request "/main.js") => "http://example.com/somewhere/main.js"
+   (bundle-paths request ["app.js"]) => ["http://example.com/somewhere/main.js"]))

--- a/test/optimus/optimizations/concatenate_bundles_test.clj
+++ b/test/optimus/optimizations/concatenate_bundles_test.clj
@@ -57,6 +57,15 @@
      "/assets/styles.css"])
 
 (fact
+ "Bundles live under the same context path as its sources"
+
+ (->> (concatenate-bundles [{:path "/main.css" :contents "" :bundle "styles.css" :context-path "/test"}]
+                           {:bundle-url-prefix "/assets"})
+      (map #(select-keys % [:context-path :path])))
+ => [{:context-path "/test" :path "/main.css"}
+     {:context-path "/test" :path "/assets/styles.css"}])
+
+(fact
  "Throws when bundling assets with different context-paths"
 
  (concatenate-bundles [{:path "/main.css" :contents "" :bundle "styles.css" :context-path "/test"}

--- a/test/optimus/optimizations/concatenate_bundles_test.clj
+++ b/test/optimus/optimizations/concatenate_bundles_test.clj
@@ -55,3 +55,19 @@
       (map :path))
  => ["/main.css"
      "/assets/styles.css"])
+
+(fact
+ "Throws when bundling assets with different context-paths"
+
+ (concatenate-bundles [{:path "/main.css" :contents "" :bundle "styles.css" :context-path "/test"}
+                       {:path "/other.css" :contents "" :bundle "styles.css" :context-path "/lol"}]
+                      {:bundle-url-prefix "/assets"})
+ => (throws Exception))
+
+(fact
+ "Throws when bundling assets with different base-urls"
+
+ (concatenate-bundles [{:path "/main.css" :contents "" :bundle "styles.css" :base-url "http://cdn"}
+                       {:path "/other.css" :contents "" :bundle "styles.css" :base-url "http://cdn2"}]
+                      {:bundle-url-prefix "/assets"})
+ => (throws Exception))

--- a/test/optimus/strategies_test.clj
+++ b/test/optimus/strategies_test.clj
@@ -165,3 +165,36 @@
         "resources directory is watched when :assets-dir option is not specified"
         (let [app (serve-live-assets-autorefresh noop get-assets dont-optimize {})]
           @watchdir-path => (clojure.java.io/file "resources")))))))
+
+(fact
+ "serve-live-assets serves the assets :contents when the request :uri
+  matches the :context-path and :path."
+
+ (defn get-assets []
+   [{:path "/code.js" :context-path "/somewhere" :contents "1 + 2"}])
+
+ (let [app (serve-live-assets noop get-assets dont-optimize {})]
+   (app {:uri "/code.js"}) => nil
+   (app {:uri "/somewhere/code.js"}) => {:status 200 :body "1 + 2"}))
+
+(fact
+ "serve-live-assets-autorefresh serves the assets :contents when the
+  request :uri matches the :context-path and :path."
+
+ (defn get-assets []
+   [{:path "/code.js" :context-path "/somewhere" :contents "1 + 2"}])
+
+ (let [app (serve-live-assets-autorefresh noop get-assets dont-optimize {})]
+   (app {:uri "/code.js"}) => nil
+   (app {:uri "/somewhere/code.js"}) => {:status 200 :body "1 + 2"}))
+
+(fact
+ "serve-frozen-assets serves the assets :contents when the request :uri
+  matches the :context-path and :path."
+
+ (defn get-assets []
+   [{:path "/code.js" :context-path "/somewhere" :contents "1 + 2"}])
+
+ (let [app (serve-frozen-assets noop get-assets dont-optimize {})]
+   (app {:uri "/code.js"}) => nil
+   (app {:uri "/somewhere/code.js"}) => {:status 200 :body "1 + 2"}))


### PR DESCRIPTION
Sometimes apps go into production not at the root of a server, but under some
virtual directory/context path, e.g. http://example.com/my-app/

This commit introduces a `:context-path` option that can be added to assets. In
the above example, adding `:context-path "/my-app"` to all assets saves you the
hassle of actually creating said directory in `resources/public` and having to
mention said directory name in build configurations etc.

`:context-path` also enables you to ignore the context path at development time,
and easily change it in one place.