### PR TITLE
Recover from bad zip files on class-path

### DIFF
--- a/src/optimus/class_path.clj
+++ b/src/optimus/class_path.clj
@@ -18,11 +18,14 @@
     [(.getCanonicalPath file)]))
 
 (defn get-jar-paths [jar]
-  (->> jar
-       (java.util.zip.ZipFile.)
-       (.entries)
-       (enumeration-seq)
-       (map (fn [#^ZipEntry e] (.getName e)))))
+  (if-let [zip (try
+                 (java.util.zip.ZipFile. jar)
+                 (catch Exception e nil))]
+    (->> zip
+         (.entries)
+         (enumeration-seq)
+         (map (fn [#^ZipEntry e] (.getName e))))
+    []))
 
 (defn get-resource-paths [path]
   (let [path-plus-slash-length (inc (count path))


### PR DESCRIPTION
Running optimus inside Datomic Ions, I was getting an exception "zip file is empty". With this patch, get-jar-paths returns [] if there is any problem opening the zip file.

If a more focussed catch is preferable, the exception I'm getting is:

    #error {:cause "zip file is empty"
            :via [{:type java.util.zip.ZipException, :message "zip file is empty"}]}