### PR TITLE
Make asset loading work cross-platform (Windows, *nix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Let's look at an example:
                         "/styles/main.css"]) ;; 9
    (assets/load-bundles "public" ;; 10
                         {"lib.js" ["/scripts/ext/angular.js"
-                                   #"/scripts/ext/.+\.js$"] ;; 11
+                                   ["scripts" "ext" "*.js"]] ;; 11
                          "app.js" ["/scripts/controllers.js"
                                    "/scripts/directives.js"]})
    (assets/load-assets "public" ;; 12
@@ -129,13 +129,24 @@ Let's look at an example:
 
 10. You can declare several bundles at once with `load-bundles`.
 
-11. You can use regexen to find multiple files without specifying each
+11. You can use glob patterns to find multiple files without specifying each
     individually. Make sure you're specific enough to avoid including
     weird things out of other jars on the class path.
 
     Notice that `angular.js` is included first, even tho it is
-    included by the regex. This way you can make sure dependencies are
+    included by the glob. This way you can make sure dependencies are
     loaded before their dependents.
+    
+    The glob patterns compile down to standard java.nio.file.PathMatcher
+    globs.
+    
+    Full documentation of supported glob patterns can be found here:
+    
+    https://docs.oracle.com/javase/7/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)
+    
+    You can also use regexps to match, but they are not inherently cross
+    platform (macOS, Linux, Windows, ...), so it's probably safer to use
+    globs.
 
 12. You can add individual assets that aren't part of a bundle, but
     should be optimized and served through Optimus. This is useful to

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,6 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/core.memoize "0.5.9"]
                  [org.clojure/data.codec "0.1.0"]
-                 [pathetic "0.5.1"]
                  [clj-time "0.12.0"]
                  [magnars/clj-v8 "0.1.6"]
                  [juxt/dirwatch "0.2.3"]

--- a/src/optimus/class_path.clj
+++ b/src/optimus/class_path.clj
@@ -1,11 +1,14 @@
 (ns optimus.class-path
   (:require [clojure.string :as s])
   (:import [java.io File]
+           (java.util.regex Pattern)
            [java.util.zip ZipFile ZipEntry]))
 
+(def file-separator-pattern (Pattern/compile (File/pathSeparator)))
+
 (defn class-path-elements []
-  (->> (s/split (System/getProperty "java.class.path" ".") #":")
-       (remove (fn [#^String s] (.contains s "/.m2/")))))
+  (->> (s/split (System/getProperty "java.class.path" ".") file-separator-pattern)
+       (remove (fn [#^String s] (.contains s (str (File/separator) ".m2" (File/separator)))))))
 ;; there are major performance improvements to be gained by not
 ;; traversing the entirety of the class path when running locally and
 ;; picking up files from the class path for every request. Since

--- a/src/optimus/digest.clj
+++ b/src/optimus/digest.clj
@@ -16,7 +16,7 @@
 (defn sha-1 [contents]
   (bytes->hex-str
     (.digest (MessageDigest/getInstance "SHA-1")
-      (.getBytes contents))))
+      (.getBytes contents "UTF-8"))))
 
 (defn base64-string [contents]
-  (String. (b64/encode (.getBytes contents)) "UTF-8"))
+  (String. (b64/encode (.getBytes contents "UTF-8")) "UTF-8"))

--- a/src/optimus/export.clj
+++ b/src/optimus/export.clj
@@ -9,8 +9,9 @@
 (defn- save-asset-to-path [asset path]
   (if-let [contents (:contents asset)]
     (spit path contents)
-    (io/copy (io/input-stream (:resource asset))
-             (FileOutputStream. (io/file path)))))
+    (with-open [input-stream (io/input-stream (:resource asset))
+                output-stream (FileOutputStream. (io/file path))]
+      (io/copy input-stream output-stream))))
 
 (defn save-assets [assets target-dir]
   (doseq [asset assets]

--- a/test/optimus/assets_test.clj
+++ b/test/optimus/assets_test.clj
@@ -45,41 +45,54 @@
              ["/styles/main.css" ""]
              ["/external/kalendae.css" ""]]
   (fact
-   "You can load multiple assets using regex."
+   "You can load multiple assets using glob."
 
-   (->> (load-assets public-dir [#"/styles/.+\.css$"])
+   (->> (load-assets public-dir [["styles" "*.css"]])
         (map :path)
         (set)) => #{"/styles/reset.css"
                     "/styles/main.css"})
 
   (fact
+   "You can load multiple assets using regex."
+
+   (->> (load-assets public-dir [#"styles.+\.css$"])
+        (map :path)
+        (set)) => #{"/styles/reset.css"
+                    "/styles/main.css"})
+
+  (fact
+   "If no files match the glob, you want to know."
+
+   (load-assets public-dir [["stlyes" "*.css"]]) => (throws Exception "No files matched [\"stlyes\" \"*.css\"]"))
+
+  (fact
    "If no files match the regex, you want to know."
 
-   (load-assets public-dir [#"/stlyes/.+\.css%"]) => (throws Exception "No files matched regex /stlyes/.+\\.css%"))
+   (load-assets public-dir [#"stlyes.+\.css$"]) => (throws Exception "No files matched stlyes.+\\.css$"))
 
   (fact
    "If you need the files in a specific order, you can list the
     ordered ones first."
 
    (->> (load-assets public-dir ["/styles/reset.css"
-                                 #"/styles/.+\.css$"])
+                                 ["styles" "*.css"]])
         (map :path)) => ["/styles/reset.css"
                          "/styles/main.css"])
 
   (fact
    (->> (load-assets public-dir ["/styles/main.css"
-                                 #"/styles/.+\.css$"])
+                                 ["styles" "*.css"]])
         (map :path)) => ["/styles/main.css"
                          "/styles/reset.css"]))
 
 (fact
- "Emacs file artifacts are ignored by the regex matcher."
+ "Emacs file artifacts are ignored by the matcher."
 
  (with-files [["/app/code.js" ""]
               ["/app/#code.js#" ""]
               ["/app/.#code.js" ""]]
 
-   (->> (load-assets public-dir [#"/app/*"])
+   (->> (load-assets public-dir [["app" "*"]])
         (map :path)) => ["/app/code.js"]))
 
 (fact
@@ -198,9 +211,9 @@
                                                                   :bundle "app.js"}])
 
   (fact
-   "Files matched with a regexp are also part of the bundle."
+   "Files matched with a pattern are also part of the bundle."
 
-   (set (map :path (load-bundle public-dir "app.js" [#"/.+\.js$"])))) => #{"/code.js" "/more.js"}
+   (set (map :path (load-bundle public-dir "app.js" [["*.js"]])))) => #{"/code.js" "/more.js"}
 
    (fact
     "There's load-bundles to reduce verbosity."

--- a/test/optimus/digest_test.clj
+++ b/test/optimus/digest_test.clj
@@ -6,7 +6,7 @@
 (fact (sha-1 "abc") => "a9993e364706816aba3e25717850c26c9cd0d89d")
 (fact (sha-1 "def") => "589c22335a381f122d129225f5c0ba3056ed5811")
 
-(def blank-gif (slurp (io/resource "blank.gif")))
+(def blank-gif (slurp (io/resource "blank.gif") :encoding "UTF-8"))
 
 (fact (base64-string "hello world") => "aGVsbG8gd29ybGQ=")
 (fact (base64-string blank-gif) => "R0lGODlhAQABAO+/vQAAAAAA77+977+977+9Ie+/vQQBAAAAACwAAAAAAQABAAACAUQAOw==")


### PR DESCRIPTION
Note: this pull request depends on https://github.com/magnars/optimus/pull/66. The tests are running fine on travis/unix, but not on Windows, as it stands now.

I'll rebase the pull request against the JSR223 PR once it's ready. For now, this PR exists for quiet contemplation and discussion :) 

* Changed optimus.paths to use java.nio.Path and make it work so that it
  does not rely on the paths on the OS level looking like URLs. On
  Windows, a \path\looks\like\this, so we parse it out, iterate the
  segments of the path, and generate URLs based on that. Removing
  dependency to "pathetic", the previously used path library.
* Changed optimus.assets.creation to support java.nio.Path based glob
  patterns, expressed as a vector. Also updated README to use these
  as the canonical path matcher, since regexps are tricky to make cross
  platform. Regexes are still supported, though.
* Parse java.class.path properly on Windows by using File/pathSeparator
* Changed digest code to explicitly use UTF-8 encoding. The tests
  assumes that the encoding is UTF-8, and this has no effect on
  deployments other than SHAs potentially changing without files
  changing if you happened to run your optimus code on e.g. Windows
  today.
* Changed optimus.export to close the IO streams it creates. It's
  good practice to close them, and Windows complains a bit more when
  they're not closed (the JVM is unable to delete the files associated
  with the streams)