### PR TITLE
Transpiling to ES5 before minifying js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,14 @@ target
 node_modules
 /resources/uglify.js
 /resources/clean-css.js
+/resources/babel.js
 /.lein-env
 /pom.xml
 /pom.xml.asc
 /.nrepl-port
+/package-lock.json
+/package.json
+.calva/
+.clj-kondo/
+.devcontainer/
+.lsp/

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 BROWSERIFY_VERSION=10.2.6
 CLEAN_CSS_VERSION=3.0.7
 UGLIFY_VERSION=2.4.24
+BABEL_VERSION=7.20.13
 
 RESOURCES_PATH=resources
 UGLIFY_TARGET=$(RESOURCES_PATH)/uglify.js
@@ -33,10 +34,14 @@ $(CLEAN_CSS_PATH):
 $(UGLIFY_CMD):
 	npm install uglify-js@$(UGLIFY_VERSION)
 
+babel: $(RESOURCES_PATH)
+	npm install @babel/standalone@$(BABEL_VERSION)
+	cp node_modules/@babel/standalone/babel.min.js resources/babel.js
+
 $(UGLIFY_TARGET): $(UGLIFY_CMD) $(RESOURCES_PATH)
 	$(UGLIFY_CMD) --self -c -m -o resources/uglify.js
 
 $(CLEAN_CSS_TARGET): $(BROWSERIFY_CMD) $(CLEAN_CSS_PATH) $(RESOURCES_PATH)
 	$(BROWSERIFY_CMD)  -r clean-css -o resources/clean-css.js
 
-all: $(UGLIFY_TARGET) $(CLEAN_CSS_TARGET)
+all: $(UGLIFY_TARGET) $(CLEAN_CSS_TARGET) babel

--- a/src/optimus/optimizations/minify.clj
+++ b/src/optimus/optimizations/minify.clj
@@ -1,7 +1,8 @@
 (ns optimus.optimizations.minify
   (:require
     [clojure.string :as str]
-    [optimus.js :as js]))
+    [optimus.js :as js]
+    [clojure.java.io :as jio]))
 
 (defn- escape [str]
   (-> str
@@ -23,10 +24,14 @@
       (str/replace "\r\n" "\n")
       (str/replace "\r" "\n")))
 
+(def ^String babel
+  (slurp (clojure.java.io/resource "babel.js")))
+
 (defn- js-minification-code
   [js options]
   (str "(function () {
-        var ast = UglifyJS.parse('" (escape (normalize-line-endings js)) "');
+        var transpiled = Babel.transform('" (escape (normalize-line-endings js)) "', { presets: ['env'], sourceType: 'script' }).code;
+        var ast = UglifyJS.parse(transpiled);
         ast.figure_out_scope();
         var compressor = UglifyJS.Compressor();
         var compressed = ast.transform(compressor);
@@ -47,6 +52,7 @@
   []
   (let [engine (js/make-engine)]
     (.eval engine uglify)
+    (.eval engine babel)
     engine))
 
 (defn minify-js

--- a/src/optimus/optimizations/minify.clj
+++ b/src/optimus/optimizations/minify.clj
@@ -2,7 +2,7 @@
   (:require
     [clojure.string :as str]
     [optimus.js :as js]
-    [clojure.java.io :as jio]))
+    [clojure.java.io :as io]))
 
 (defn- escape [str]
   (-> str
@@ -25,7 +25,7 @@
       (str/replace "\r" "\n")))
 
 (def ^String babel
-  (slurp (clojure.java.io/resource "babel.js")))
+  (slurp (io/resource "babel.js")))
 
 (defn- js-minification-code
   [js options]
@@ -46,7 +46,7 @@
 (def ^String uglify
   "The UglifyJS source code, free of dependencies and runnable in a
   stripped context"
-  (slurp (clojure.java.io/resource "uglify.js")))
+  (slurp (io/resource "uglify.js")))
 
 (defn prepare-uglify-engine
   []
@@ -104,7 +104,7 @@
 (def clean-css
   "The clean-css source code, free of dependencies and runnable in a
   stripped context"
-  (slurp (clojure.java.io/resource "clean-css.js")))
+  (slurp (io/resource "clean-css.js")))
 
 (defn prepare-clean-css-engine
   "Minify CSS with the bundled clean-css version"

--- a/test/optimus/optimizations/minify_test.clj
+++ b/test/optimus/optimizations/minify_test.clj
@@ -19,6 +19,16 @@
  (minify-js "var rsingleTag = /^<(\\w+)\\s*\\/?>(?:<\\/\\1>|)$/;") => "var rsingleTag=/^<(\\w+)\\s*\\/?>(?:<\\/\\1>|)$/;")
 
 (fact
+ "Transpiles lambda notation to valid ES5"
+ (minify-js "const hello = (hey) => { console.info(hey)};")
+ => "var hello=function(o){console.info(o)};")
+
+(fact
+ "Transpiles class definition to valied ES5"
+ (minify-js "class Test {}")
+ => "function _typeof(e){\"@babel/helpers - typeof\";return(_typeof=\"function\"==typeof Symbol&&\"symbol\"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&\"function\"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?\"symbol\":typeof e})(e)}function _defineProperties(e,t){for(var r=0;r<t.length;r++){var o=t[r];o.enumerable=o.enumerable||!1,o.configurable=!0,\"value\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o)}}function _createClass(e,t,r){return t&&_defineProperties(e.prototype,t),r&&_defineProperties(e,r),Object.defineProperty(e,\"prototype\",{writable:!1}),e}function _toPropertyKey(e){var t=_toPrimitive(e,\"string\");return\"symbol\"===_typeof(t)?t:String(t)}function _toPrimitive(e,t){if(\"object\"!==_typeof(e)||null===e)return e;var r=e[Symbol.toPrimitive];if(void 0!==r){var o=r.call(e,t||\"default\");if(\"object\"!==_typeof(o))return o;throw new TypeError(\"@@toPrimitive must return a primitive value.\")}return(\"string\"===t?String:Number)(e)}function _classCallCheck(e,t){if(!(e instanceof t))throw new TypeError(\"Cannot call a class as a function\")}var Test=_createClass(function e(){\"use strict\";_classCallCheck(this,e)});")
+
+(fact
  "Throws exception on syntax errors"
  (minify-js "var hello =") => (throws Exception "Unexpected token: eof (undefined) (line 1, col 11)"))
 

--- a/test/optimus/optimizations/minify_test.clj
+++ b/test/optimus/optimizations/minify_test.clj
@@ -29,6 +29,11 @@
  => "function _typeof(e){\"@babel/helpers - typeof\";return(_typeof=\"function\"==typeof Symbol&&\"symbol\"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&\"function\"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?\"symbol\":typeof e})(e)}function _defineProperties(e,t){for(var r=0;r<t.length;r++){var o=t[r];o.enumerable=o.enumerable||!1,o.configurable=!0,\"value\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o)}}function _createClass(e,t,r){return t&&_defineProperties(e.prototype,t),r&&_defineProperties(e,r),Object.defineProperty(e,\"prototype\",{writable:!1}),e}function _toPropertyKey(e){var t=_toPrimitive(e,\"string\");return\"symbol\"===_typeof(t)?t:String(t)}function _toPrimitive(e,t){if(\"object\"!==_typeof(e)||null===e)return e;var r=e[Symbol.toPrimitive];if(void 0!==r){var o=r.call(e,t||\"default\");if(\"object\"!==_typeof(o))return o;throw new TypeError(\"@@toPrimitive must return a primitive value.\")}return(\"string\"===t?String:Number)(e)}function _classCallCheck(e,t){if(!(e instanceof t))throw new TypeError(\"Cannot call a class as a function\")}var Test=_createClass(function e(){\"use strict\";_classCallCheck(this,e)});")
 
 (fact
+ "Transpiles 'let' to valid ES5 and minifies expressions"
+ (minify-js "let apekatt = 7+3;")
+ => "var apekatt=10;")
+
+(fact
  "Throws exception on syntax errors"
  (minify-js "var hello =") => (throws Exception "Unexpected token: eof (undefined) (line 1, col 11)"))
 


### PR DESCRIPTION
This change uses babel-standalone to transform modern javascript to ES5 during minifying. This has to be done since uglify-js doesn't support any newer standards.