### PR TITLE
Support directly using optimized path in link/file-path

### DIFF
--- a/src/optimus/link.clj
+++ b/src/optimus/link.clj
@@ -6,12 +6,13 @@
 
 (defn file-path [request path & {:as options}]
   (let [path (->> request :optimus-assets
-                  (filter #(= path (assets/original-path %)))
+                  (filter #(or (= path (:path %))
+                               (= path (assets/original-path %))))
                   (remove :outdated)
                   (first))]
     (if path
       (full-path path)
-      (if-let [fallback (:fallback options)]
+      (when-let [fallback (:fallback options)]
         (file-path request fallback)))))
 
 (defn- bundle-paths-1 [optimus-assets bundle]

--- a/test/optimus/link_test.clj
+++ b/test/optimus/link_test.clj
@@ -24,6 +24,14 @@
    (file-path request "/unknown.png" :fallback "/bg.png") => "/bg.png"))
 
 (fact
+  "You can link to optimized paths."
+
+  (let [request {:optimus-assets [{:path "/main.js" :bundle "app.js" :outdated true}
+                                  {:path "/12/m.js" :bundle "app.js"}]}]
+
+    (file-path request "/12/m.js") => "/12/m.js"))
+
+(fact
  "You can link to files specified by their bundle names."
 
  (let [request {:optimus-assets [{:path "/bg.png"}


### PR DESCRIPTION
Currently using `(link/file-path "/optimized-path.js")` returns nil. This fix causes the optimized path to be returned back.