### PR TITLE
Fix link path regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You might also be interested in:
 
 ## Install
 
-Add `[optimus "2023.10.19"]` to `:dependencies` in your `project.clj`.
+Add `[optimus "2023.11.21"]` to `:dependencies` in your `project.clj`.
 
 This project no longer uses Semantic Versioning. Instead we're aiming to never
 break the API. Feel free to check out the [change log](#change-log).
@@ -756,7 +756,7 @@ Likewise, for any other JS engine that implements `javax.script` interfaces.
 There were breaking changes in `0.16`, `0.17` and `0.19`. If you're upgrading,
 you might want to [read more about them](breaking-changes.md).
 
-#### From 2023.10.13 to 2023.10.19
+#### From 2023.10.13 to 2023.11.21
 
 - Update clean-css to 5.3.2
 
@@ -768,6 +768,11 @@ you might want to [read more about them](breaking-changes.md).
       This used to be 5000 chars on a single line, now reduced to 1000 chars.
       This due to smaller clojurescript projects not needing 5000 chars in
       total. We're hoping people don't write 1000 chars wide lines manually.
+
+- Support directly using optimized path in link/file-path
+
+      In case you already have the optimized path for some reason, this will no
+      longer trip you up.
 
 #### From 2023-10-03 to 2023.10.13
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img align="right" src="optimus.png"> Optimus [![Build Status](https://secure.travis-ci.org/magnars/optimus.png)](http://travis-ci.org/magnars/optimus)
+# <img align="right" src="optimus.png"> Optimus
 
 A Ring middleware for frontend performance optimization.
 
@@ -44,7 +44,7 @@ You might also be interested in:
 
 ## Install
 
-Add `[optimus "2023.11.21"]` to `:dependencies` in your `project.clj`.
+Add `[optimus "2025.01.15"]` to `:dependencies` in your `project.clj`.
 
 This project no longer uses Semantic Versioning. Instead we're aiming to never
 break the API. Feel free to check out the [change log](#change-log).
@@ -871,6 +871,12 @@ Likewise, for any other JS engine that implements `javax.script` interfaces.
 
 There were breaking changes in `0.16`, `0.17` and `0.19`. If you're upgrading,
 you might want to [read more about them](breaking-changes.md).
+
+#### From 2023.11.21 to 2025.01.15
+
+- Avoid private functions, no need to hoard useful stuff
+- Make available `assets/get-contents` convenience function
+- Make available `assets/get-asset-by-path` convenience function
 
 #### From 2023.10.13 to 2023.11.21
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject optimus "2023.10.19"
+(defproject optimus "2023.11.21"
   :description "A Ring middleware for frontend performance optimization."
   :url "http://github.com/magnars/optimus"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject optimus "2023.11.21"
+(defproject optimus "2025.01.15"
   :description "A Ring middleware for frontend performance optimization."
   :url "http://github.com/magnars/optimus"
   :license {:name "Eclipse Public License"

--- a/src/optimus/assets.clj
+++ b/src/optimus/assets.clj
@@ -17,7 +17,7 @@
 
 (defn get-asset-by-path [request path]
   (->> request :optimus-assets
-       (filter #(= path (original-path %)))
+       (filter #(or (= path (original-path %)) (= path (:path %))))
        (remove :outdated)
        (first)))
 

--- a/src/optimus/assets.clj
+++ b/src/optimus/assets.clj
@@ -1,5 +1,6 @@
 (ns optimus.assets
-  (:require [optimus.assets.creation :refer [load-asset]]
+  (:require [clojure.java.io :as io]
+            [optimus.assets.creation :refer [load-asset]]
             [optimus.assets.load-css]
             [potemkin :refer [import-vars]]))
 
@@ -19,6 +20,10 @@
        (filter #(= path (original-path %)))
        (remove :outdated)
        (first)))
+
+(defn get-contents [asset]
+  (or (:contents asset)
+      (io/input-stream (:resource asset))))
 
 (defn with-prefix
   [prefix & paths]

--- a/src/optimus/assets.clj
+++ b/src/optimus/assets.clj
@@ -14,6 +14,12 @@
               load-bundles
               original-path])
 
+(defn get-asset-by-path [request path]
+  (->> request :optimus-assets
+       (filter #(= path (original-path %)))
+       (remove :outdated)
+       (first)))
+
 (defn with-prefix
   [prefix & paths]
   (map (partial str prefix)

--- a/src/optimus/assets/creation.clj
+++ b/src/optimus/assets/creation.clj
@@ -26,13 +26,13 @@
   (or (io/resource (str public-dir path))
       (throw (FileNotFoundException. path))))
 
-(defn- file-last-modified [#^URL resource]
+(defn file-last-modified [#^URL resource]
   (let [url-connection (.openConnection resource)
         modified (.getLastModified url-connection)]
     (.close (.getInputStream url-connection))
     (* (.intValue (/ modified 1000)) 1000)))
 
-(defn- jar-file-last-modified [#^URL resource]
+(defn jar-file-last-modified [#^URL resource]
   (let [[jar-path file-path] (-> (.getPath resource)
                                  (subs 5)
                                  (str/split #"!/"))]
@@ -68,7 +68,7 @@
   [public-dir path]
   (create-binary-asset public-dir path))
 
-(defn- load-asset-and-refs [public-dir path]
+(defn load-asset-and-refs [public-dir path]
   (let [asset (load-asset public-dir path)]
     (concat [asset] (mapcat #(load-asset-and-refs public-dir %) (:references asset)))))
 
@@ -89,7 +89,7 @@
   (file-system-path-to-url-path
     (slice-path-to-after public-dir s)))
 
-(defn- emacs-file-artefact? [#^String path]
+(defn emacs-file-artefact? [#^String path]
   (when-let [filename (just-the-filename path)]
     (or (.startsWith filename ".#")
         (and (.startsWith filename "#")

--- a/src/optimus/assets/load_css.clj
+++ b/src/optimus/assets/load_css.clj
@@ -5,7 +5,7 @@
 
 (def css-url-re #"(?:url\( *['\"]?([^\)]+?)['\"]?\)|@import ['\"](.+?)['\"] *)")
 
-(defn- data-url? [#^String url]
+(defn data-url? [#^String url]
   (.startsWith url "data:"))
 
 (defn external-url? [#^String url]
@@ -19,24 +19,24 @@
       (external-url? url)
       (behavior-url? url)))
 
-(defn- url-match [[match & urls]]
+(defn url-match [[match & urls]]
   (first (remove nil? urls)))
 
-(defn- match-url-to-absolute [original-path [match :as matches]]
+(defn match-url-to-absolute [original-path [match :as matches]]
   (let [url (url-match matches)]
     (if (leave-url-alone? url)
       match
       (str/replace match url (to-absolute-url original-path url)))))
 
-(defn- make-css-urls-absolute [file]
+(defn make-css-urls-absolute [file]
   (->> (partial match-url-to-absolute (original-path file))
        (str/replace (:contents file) css-url-re)
        (assoc-in file [:contents])))
 
-(defn- remove-url-appendages [s]
+(defn remove-url-appendages [s]
   (first (str/split s #"[\?#]")))
 
-(defn- paths-in-css [file]
+(defn paths-in-css [file]
   (->> file :contents
        (re-seq css-url-re)
        (map url-match)

--- a/src/optimus/digest.clj
+++ b/src/optimus/digest.clj
@@ -9,7 +9,7 @@
     #(+ % 0x100)
     #(bit-and % 0xff)))
 
-(defn- bytes->hex-str [bytes]
+(defn bytes->hex-str [bytes]
   (apply str
     (map byte->hex-str bytes)))
 

--- a/src/optimus/export.clj
+++ b/src/optimus/export.clj
@@ -3,10 +3,10 @@
             [optimus.asset :as asset])
   (:import [java.io FileOutputStream]))
 
-(defn- create-folders [path]
+(defn create-folders [path]
   (.mkdirs (.getParentFile (io/file path))))
 
-(defn- save-asset-to-path [asset path]
+(defn save-asset-to-path [asset path]
   (if-let [contents (:contents asset)]
     (spit path contents)
     (with-open [input-stream (io/input-stream (:resource asset))

--- a/src/optimus/link.clj
+++ b/src/optimus/link.clj
@@ -5,13 +5,9 @@
   (str base-url context-path path))
 
 (defn file-path [request path & {:as options}]
-  (let [path (->> request :optimus-assets
-                  (filter #(or (= path (:path %))
-                               (= path (assets/original-path %))))
-                  (remove :outdated)
-                  (first))]
-    (if path
-      (full-path path)
+  (let [asset (assets/get-asset-by-path request path)]
+    (if asset
+      (full-path asset)
       (when-let [fallback (:fallback options)]
         (file-path request fallback)))))
 

--- a/src/optimus/link.clj
+++ b/src/optimus/link.clj
@@ -11,7 +11,7 @@
       (when-let [fallback (:fallback options)]
         (file-path request fallback)))))
 
-(defn- bundle-paths-1 [optimus-assets bundle]
+(defn bundle-paths-1 [optimus-assets bundle]
   (->> optimus-assets
        (filter #(= bundle (:bundle %)))
        (remove :outdated)

--- a/src/optimus/link.clj
+++ b/src/optimus/link.clj
@@ -6,12 +6,13 @@
 
 (defn file-path [request path & {:as options}]
   (let [path (->> request :optimus-assets
-                  (filter #(= path (assets/original-path %)))
+                  (filter #(or (= path (:path %))
+                               (= path (assets/original-path %))))
                   (remove :outdated)
                   (first))]
     (if path
       (full-path path)
-      (if-let [fallback (:fallback options)]
+      (when-let [fallback (:fallback options)]
         (file-path request fallback)))))
 
 (defn- bundle-paths-1 [optimus-assets bundle]

--- a/src/optimus/optimizations/add_cache_busted_expires_headers.clj
+++ b/src/optimus/optimizations/add_cache_busted_expires_headers.clj
@@ -9,11 +9,11 @@
   (:import [java.time ZonedDateTime ZoneId]
            [java.time.format DateTimeFormatter]))
 
-(defn- get-contents [file]
+(defn get-contents [file]
   (or (:contents file)
       (slurp (:resource file))))
 
-(defn- add-cache-busted-expires-header [file]
+(defn add-cache-busted-expires-header [file]
   (-> file
       (assoc :path (str (paths/just-the-path (:path file))
                         (subs (digest/sha-1 (get-contents file)) 0 12)
@@ -24,7 +24,7 @@
       (assoc-in [:headers "Expires"] (time/format-http-date
                                       (.plusYears (time/now) 10)))))
 
-(defn- by-path [path files]
+(defn by-path [path files]
   (first (filter #(= path (:path %)) files)))
 
 (defn qualify-url [{:keys [base-url context-path path]}]
@@ -35,14 +35,14 @@
 (defn inverse-string-length [^String s]
   (- (.length s)))
 
-(defn- replace-referenced-url [file old new]
+(defn replace-referenced-url [file old new]
   (update-in file [:contents] #(str/replace % old new)))
 
-(defn- replace-referenced-urls [file old->new]
+(defn replace-referenced-urls [file old->new]
   (reduce #(replace-referenced-url %1 %2 (old->new %2)) file
           (sort-by inverse-string-length (:references file))))
 
-(defn- replace-referenced-urls-with-new-ones [file files]
+(defn replace-referenced-urls-with-new-ones [file files]
   (if-let [references (:references file)]
     (let [orig->curr (into {} (map (juxt original-path qualify-url) files))]
       (-> file
@@ -50,7 +50,7 @@
           (assoc :references (set (replace orig->curr references)))))
     file))
 
-(defn- add-cache-busted-expires-headers-in-order [to-replace files]
+(defn add-cache-busted-expires-headers-in-order [to-replace files]
   ;; three cases:
 
   ;; 1. nothing more to replace? return the files

--- a/src/optimus/optimizations/add_last_modified_headers.clj
+++ b/src/optimus/optimizations/add_last_modified_headers.clj
@@ -1,7 +1,7 @@
 (ns optimus.optimizations.add-last-modified-headers
   (:require [optimus.time :as time]))
 
-(defn- add-last-modified-headers-1
+(defn add-last-modified-headers-1
   [asset]
   (if (:last-modified asset)
     (assoc-in asset [:headers "Last-Modified"]

--- a/src/optimus/optimizations/concatenate_bundles.clj
+++ b/src/optimus/optimizations/concatenate_bundles.clj
@@ -3,7 +3,7 @@
             [clojure.string :as str]
             [optimus.homeless :refer [assoc-non-nil max?]]))
 
-(defn- verify-unique-qualifiers [assets qualifier]
+(defn verify-unique-qualifiers [assets qualifier]
   (let [xs (into #{} (map qualifier assets))]
     (when (< 1 (count xs))
       (throw (ex-info (format "Cannot bundle assets with different %ss: %s"
@@ -11,7 +11,7 @@
                               (str/join " " (map #(if (nil? %) "nil" (str "\"" % "\"")) (sort xs))))
                       {:assets assets})))))
 
-(defn- concatenate-bundle [prefix [name assets]]
+(defn concatenate-bundle [prefix [name assets]]
   (verify-unique-qualifiers assets :context-path)
   (verify-unique-qualifiers assets :base-url)
   (when name
@@ -23,7 +23,7 @@
         (assoc-non-nil :references (apply union (map :references assets)))
         (assoc-non-nil :last-modified (max? (keep :last-modified assets))))))
 
-(defn- mark-as-bundled [asset]
+(defn mark-as-bundled [asset]
   (if (:bundle asset)
     (-> asset
         (dissoc :bundle)

--- a/src/optimus/optimizations/inline_css_imports.clj
+++ b/src/optimus/optimizations/inline_css_imports.clj
@@ -5,10 +5,10 @@
 
 (def import-re #"@import (?:url)?[('\"]{1,2}([^']+?)[)'\"]{1,2} ?([^;]*);")
 
-(defn- by-path [path assets]
+(defn by-path [path assets]
   (first (filter #(= path (:path %)) assets)))
 
-(defn- inline-import-match [asset assets [match path media]]
+(defn inline-import-match [asset assets [match path media]]
   (if (external-url? path)
     (throw (Exception. (str "Import of external URL " path " in " (:path asset) " is strongly adviced against. It's a performance killer. In fact, there's no option to allow this. Use a link in your HTML instead. Open an issue if you really, really need it.")))
     (let [contents (:contents (by-path path assets))]
@@ -16,13 +16,13 @@
         contents
         (str "@media " media " { " contents " }")))))
 
-(defn- is-css [#^String path]
+(defn is-css [#^String path]
   (.endsWith path ".css"))
 
-(defn- referenced-assets [asset assets]
+(defn referenced-assets [asset assets]
   (map #(by-path % assets) (:references asset)))
 
-(defn- inline-css-imports-1 [asset assets]
+(defn inline-css-imports-1 [asset assets]
   (if-not (is-css (:path asset))
     asset
     (-> asset

--- a/src/optimus/optimizations/minify.clj
+++ b/src/optimus/optimizations/minify.clj
@@ -4,7 +4,7 @@
             [clojure.string :as str]
             [optimus.js :as js]))
 
-(defn- escape [str]
+(defn escape [str]
   (-> str
       (str/replace "\\" "\\\\")
       (str/replace "'" "\\'")
@@ -27,7 +27,7 @@
 (def ^String babel
   (slurp (io/resource "babel.js")))
 
-(defn- js-minification-code
+(defn js-minification-code
   [js options]
   (let [js-code (escape (normalize-line-endings js))]
     (str "(function () {"
@@ -111,7 +111,7 @@
           (or (not-empty options) default-clean-css-settings)))
       (assoc :inline false)))
 
-(defn- css-minification-code
+(defn css-minification-code
   [css options]
   (str "(function () {
         var CleanCSS = require('clean-css');

--- a/src/optimus/strategies.clj
+++ b/src/optimus/strategies.clj
@@ -1,13 +1,12 @@
 (ns optimus.strategies
   (:require [clojure.core.memoize :as memo]
-            [clojure.java.io :as io]
             [nextjournal.beholder :as beholder]
             [optimus.asset :as asset]
+            [optimus.assets :as assets]
             [optimus.homeless :refer [assoc-non-nil]]))
 
 (defn- serve-asset [asset]
-  (-> {:status 200 :body (or (:contents asset)
-                             (io/input-stream (:resource asset)))}
+  (-> {:status 200 :body (assets/get-contents asset)}
       (assoc-non-nil :headers (:headers asset))))
 
 (defn- serve-asset-or-continue [assets path->asset app request]

--- a/src/optimus/strategies.clj
+++ b/src/optimus/strategies.clj
@@ -5,21 +5,21 @@
             [optimus.assets :as assets]
             [optimus.homeless :refer [assoc-non-nil]]))
 
-(defn- serve-asset [asset]
+(defn serve-asset [asset]
   (-> {:status 200 :body (assets/get-contents asset)}
       (assoc-non-nil :headers (:headers asset))))
 
-(defn- serve-asset-or-continue [assets path->asset app request]
+(defn serve-asset-or-continue [assets path->asset app request]
   (if-let [asset (path->asset (:uri request))]
     (serve-asset asset)
     (app (assoc request :optimus-assets assets))))
 
-(defn- collapse-equal-assets [asset-1 asset-2]
+(defn collapse-equal-assets [asset-1 asset-2]
   (when-not (= asset-1 asset-2)
     (throw (Exception. (str "Two assets have the same path \"" (:path asset-1) "\", but are not equal."))))
   asset-1)
 
-(defn- guard-against-duplicate-assets [assets]
+(defn guard-against-duplicate-assets [assets]
   (let [pb->assets (group-by (juxt :path :bundle) assets)]
     (->> assets
          (map (juxt :path :bundle))

--- a/test/optimus/assets_test.clj
+++ b/test/optimus/assets_test.clj
@@ -28,7 +28,7 @@
    "Missing files are not tolerated."
    (load-assets public-dir ["/gone.js"]) => (throws FileNotFoundException "/gone.js")))
 
-(defn- plausible-timestamp? [actual-timestamp]
+(defn plausible-timestamp? [actual-timestamp]
   (let [upstream-timestamp 1384517932000
         twenty-four-hours (* 24 3600 1000)]
     (< (- upstream-timestamp twenty-four-hours)

--- a/test/optimus/assets_test.clj
+++ b/test/optimus/assets_test.clj
@@ -246,3 +246,11 @@
     "code.js"]) => ["/scripts/angular/some.js"
                     "/scripts/angular/more.js"
                     "/scripts/angular/code.js"])
+
+(fact
+ (let [request {:optimus-assets [{:path "/bg.png"}
+                                 {:path "/main.js" :outdated true}
+                                 {:path "/12/m.js" :original-path "/main.js"}]}]
+
+   (get-asset-by-path request "/bg.png") => {:path "/bg.png"}
+   (get-asset-by-path request "/main.js") => {:path "/12/m.js" :original-path "/main.js"}))

--- a/test/optimus/link_test.clj
+++ b/test/optimus/link_test.clj
@@ -27,7 +27,7 @@
   "You can link to optimized paths."
 
   (let [request {:optimus-assets [{:path "/main.js" :bundle "app.js" :outdated true}
-                                  {:path "/12/m.js" :bundle "app.js"}]}]
+                                  {:path "/12/m.js" :bundle "app.js" :original-path "app.js"}]}]
 
     (file-path request "/12/m.js") => "/12/m.js"))
 

--- a/test/optimus/link_test.clj
+++ b/test/optimus/link_test.clj
@@ -24,6 +24,14 @@
    (file-path request "/unknown.png" :fallback "/bg.png") => "/bg.png"))
 
 (fact
+  "You can link to optimized paths."
+
+  (let [request {:optimus-assets [{:path "/main.js" :bundle "app.js" :outdated true}
+                                  {:path "/12/m.js" :bundle "app.js"}]}]
+
+    (file-path request "/12/m.js") => "/12/m.js"))
+
+(fact
  "You can link to files specified by their bundle names."
 
  (let [request {:optimus-assets [{:path "/bg.png"}


### PR DESCRIPTION
2025.01.15 introduced a regression in `optimus.link/file-path` where it no longer can route optimized paths. This commit fixes it.