### PR TITLE
Change default CSS optimizer to csso

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,14 @@ BROWSERIFY_VERSION=10.2.6
 # we are waiting for this to get merged: https://github.com/clean-css/clean-css/pull/1275
 UGLIFY_VERSION=2.4.24
 BABEL_VERSION=7.20.13
+CSSO_VERSION=5.0.5
 
 RESOURCES_PATH=resources
 UGLIFY_TARGET=$(RESOURCES_PATH)/uglify.js
 CLEAN_CSS_TARGET=$(RESOURCES_PATH)/clean-css.js
 CLEAN_CSS_PATH=node_modules/clean-css
+CSSO_TARGET=$(RESOURCES_PATH)/csso.js
+CSSO_PATH=node_modules/csso
 
 ifeq ($(OS),Windows_NT)
   UGLIFY_CMD=node_modules\.bin\uglifyjs.cmd
@@ -32,6 +35,9 @@ $(BROWSERIFY_CMD):
 $(CLEAN_CSS_PATH):
 	npm install github:bes-internal/clean-css#transition-behavior
 
+$(CSSO_PATH):
+	npm install csso@$(CSSO_VERSION)
+
 $(UGLIFY_CMD):
 	npm install uglify-js@$(UGLIFY_VERSION)
 
@@ -45,4 +51,7 @@ $(UGLIFY_TARGET): $(UGLIFY_CMD) $(RESOURCES_PATH)
 $(CLEAN_CSS_TARGET): $(BROWSERIFY_CMD) $(CLEAN_CSS_PATH) $(RESOURCES_PATH)
 	$(BROWSERIFY_CMD)  -r clean-css -o resources/clean-css.js
 
-all: $(UGLIFY_TARGET) $(CLEAN_CSS_TARGET) babel
+$(CSSO_TARGET): $(CSSO_PATH) $(RESOURCES_PATH)
+	cp node_modules/csso/dist/csso.js $(CSSO_TARGET)
+
+all: $(UGLIFY_TARGET) $(CLEAN_CSS_TARGET) $(CSSO_TARGET) babel

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Depending on how you use it, Optimus:
 - adds cache-busters to your static asset URLs
 - adds [far future Expires headers](http://developer.yahoo.com/performance/rules.html#expires)
 - minifies your JavaScript with [UglifyJS 2](https://github.com/mishoo/UglifyJS2)
-- minifies your CSS with [clean-css](https://github.com/jakubpawlowicz/clean-css)
+- minifies your CSS with [csso](https://github.com/css/csso) or [clean-css](https://github.com/jakubpawlowicz/clean-css)
 - inlines CSS imports while preserving media queries
 
 You might also be interested in:
@@ -585,7 +585,7 @@ Now, for the options. You pass them to the wrapper after the strategy:
      {:cache-live-assets 2000
       :uglify-js {:mangle-names true
                   :transpile-es6? false}
-      :clean-css {:level 2}}))
+      :csso {:restructure true}}))
 ```
 
 Values in this example are all defaults, so it's just a verbose noop.
@@ -608,7 +608,17 @@ Values in this example are all defaults, so it's just a verbose noop.
 - `:transpile-es6?` - UglifyJS does not support the new syntax in ES6. Set this
   to `true` to let Babel transpile ES6 code into ES5 before minification.
 
+#### `:csso`
+
+These options are passed straight to csso. Please see the [csso
+documentation](https://github.com/css/csso#minifysource-options) for available
+options.
+
 #### `:clean-css`
+
+When `:clean-css` is present, Optimus will use clean-css instead of csso for CSS
+optimization. clean-css is the old default, but it is no longer developed, has
+known shortcomings and is generally discouraged.
 
 These options are passed straight to clean-css. Please see the [clean-css
 documentation](https://github.com/clean-css/clean-css#constructor-options) for

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "@babel/standalone": "^7.20.13",
     "browserify": "^10.2.6",
     "clean-css": "github:bes-internal/clean-css#transition-behavior",
+    "csso": "^5.0.5",
     "uglify-js": "^2.4.24"
   }
 }

--- a/src/optimus/clean_css.clj
+++ b/src/optimus/clean_css.clj
@@ -1,0 +1,58 @@
+(ns optimus.clean-css
+  (:require [clojure.data.json :as json]
+            [clojure.java.io :as io]
+            [optimus.js :as js]))
+
+(def default-clean-css-settings
+  {:level 2})
+
+(defn create-legacy-clean-css-settings [options]
+  {:level {1 {:all true
+              :specialComments (:keep-special-comments options "'all'")}
+           2 {:all (:advanced-optimizations options true)}}
+   :format (if (:keep-line-breaks options) "keep-breaks" false)
+   :compatibility (:compatibility options "*")})
+
+(defn is-legacy-clean-css-opts? [options]
+  (seq (select-keys options [:keep-special-comments :advanced-optimizations :keep-line-breaks])))
+
+(defn get-clean-css-settings [options]
+  (-> (let [options (dissoc options :aggressive-merging)]
+        (if (is-legacy-clean-css-opts? options)
+          (create-legacy-clean-css-settings options)
+          (or (not-empty options) default-clean-css-settings)))
+      (assoc :inline false)))
+
+(defn css-minification-code
+  [css options]
+  (str "(function () {
+        var CleanCSS = require('clean-css');
+        var source = '" (js/escape (js/normalize-line-endings css)) "';
+        var options = " (json/write-str (get-clean-css-settings options)) ";
+        var minified = new CleanCSS(options).minify(source).styles;
+        return minified;
+}());"))
+
+(def clean-css
+  "The clean-css source code, free of dependencies and runnable in a
+  stripped context"
+  (slurp (io/resource "clean-css.js")))
+
+(defn create-engine
+  "Minify CSS with the bundled clean-css version"
+  []
+  (let [engine (js/make-engine)]
+    (.eval engine "var window = { XMLHttpRequest: {} };")
+    (.eval engine clean-css)
+    engine))
+
+(defn minify-css
+  ([css] (minify-css css {}))
+  ([css options]
+   (js/with-engine [engine (create-engine)]
+     (minify-css engine css options)))
+  ([engine css options]
+   (js/run-script-with-error-handling
+    engine
+    (css-minification-code css options)
+    (:path options))))

--- a/src/optimus/csso.clj
+++ b/src/optimus/csso.clj
@@ -1,0 +1,33 @@
+(ns optimus.csso
+  (:require [clojure.data.json :as json]
+            [clojure.java.io :as io]
+            [optimus.js :as js]))
+
+(defn css-minification-code [css options]
+  (str "csso.minify("
+       "'" (js/escape (js/normalize-line-endings css)) "', "
+       (json/write-str options) ").css"))
+
+(def csso (slurp (io/resource "csso.js")))
+
+(defn create-engine []
+  (let [engine (js/make-engine)]
+    (.eval engine csso)
+    engine))
+
+(defn minify
+  ([css] (minify css {}))
+  ([css options]
+   (js/with-engine [engine (create-engine)]
+     (minify engine css options)))
+  ([engine css options]
+   (js/run-script-with-error-handling
+    engine
+    (css-minification-code css options)
+    (:path options))))
+
+(comment
+
+  (minify "body { color: red; }")
+
+)

--- a/src/optimus/js.clj
+++ b/src/optimus/js.clj
@@ -1,8 +1,7 @@
 (ns optimus.js
-  (:require
-    [clojure.string :as str]
-    [clojure.java.data :as java.data]
-    [environ.core :refer [env]]))
+  (:require [clojure.java.data :as java.data]
+            [clojure.string :as str]
+            [environ.core :refer [env]]))
 
 (def default-engines
   "Officially supported JS engines (which may or may not be available
@@ -185,3 +184,14 @@
        (catch Exception e
          ;; TODO verbose logging here would be nice to inspect the wrapped script
          (throw (optimus-js-error engine file-path e)))))
+
+(defn escape [str]
+  (-> str
+      (str/replace "\\" "\\\\")
+      (str/replace "'" "\\'")
+      (str/replace "\n" "\\n")))
+
+(defn normalize-line-endings [str]
+  (-> str
+      (str/replace "\r\n" "\n")
+      (str/replace "\r" "\n")))

--- a/src/optimus/optimizations/minify.clj
+++ b/src/optimus/optimizations/minify.clj
@@ -1,6 +1,7 @@
 (ns optimus.optimizations.minify
   (:require [clojure.string :as str]
             [optimus.clean-css :as clean-css]
+            [optimus.csso :as csso]
             [optimus.js :as js]
             [optimus.uglify-js :as uglify-js]))
 
@@ -39,9 +40,13 @@
 ;; minify CSS
 
 (defn get-css-minifier [options]
-  {:engine (clean-css/create-engine)
-   :optimize #'clean-css/minify-css
-   :options (:clean-css options)})
+  (let [clean-css (:clean-css options)]
+    {:engine (clean-css/create-engine)
+     :optimize #'clean-css/minify-css
+     :options clean-css}
+    {:engine (csso/create-engine)
+     :optimize #'csso/minify
+     :options (:csso options)}))
 
 (defn minify-css [optimizer css {:keys [path]}]
   (if (looks-like-already-minified css)

--- a/src/optimus/optimizations/minify.clj
+++ b/src/optimus/optimizations/minify.clj
@@ -1,14 +1,8 @@
 (ns optimus.optimizations.minify
-  (:require [clojure.data.json :as json]
-            [clojure.java.io :as io]
-            [clojure.string :as str]
-            [optimus.js :as js]))
-
-(defn escape [str]
-  (-> str
-      (str/replace "\\" "\\\\")
-      (str/replace "'" "\\'")
-      (str/replace "\n" "\\n")))
+  (:require [clojure.string :as str]
+            [optimus.clean-css :as clean-css]
+            [optimus.js :as js]
+            [optimus.uglify-js :as uglify-js]))
 
 (defn looks-like-already-minified
   "Files with a single line over 1000 characters are considered already
@@ -19,57 +13,15 @@
        (str/split-lines)
        (some (fn [^String s] (> (.length s) 1000)))))
 
-(defn normalize-line-endings [str]
-  (-> str
-      (str/replace "\r\n" "\n")
-      (str/replace "\r" "\n")))
-
-(def ^String babel
-  (slurp (io/resource "babel.js")))
-
-(defn js-minification-code
-  [js options]
-  (let [js-code (escape (normalize-line-endings js))]
-    (str "(function () {"
-         (if (:transpile-es6? options)
-           (str "var jsCode = Babel.transform('" js-code "', { presets: ['env'], sourceType: 'script' }).code;")
-           (str "var jsCode = '" js-code "';"))
-         "var ast = UglifyJS.parse(jsCode);
-          ast.figure_out_scope();
-          var compressor = UglifyJS.Compressor();
-          var compressed = ast.transform(compressor);
-          compressed.figure_out_scope();
-          compressed.compute_char_frequency();"
-         (if (get options :mangle-names true) "compressed.mangle_names();" "")
-         "var stream = UglifyJS.OutputStream();
-          compressed.print(stream);
-          return stream.toString();
-}());")))
-
-(def ^String uglify
-  "The UglifyJS source code, free of dependencies and runnable in a
-  stripped context"
-  (slurp (io/resource "uglify.js")))
-
-(defn prepare-uglify-engine
-  []
-  (let [engine (js/make-engine)]
-    (.eval engine uglify)
-    (.eval engine babel)
-    engine))
-
 (defn minify-js
   ([js] (minify-js js {}))
   ([js options]
-   (js/with-engine [engine (prepare-uglify-engine)]
+   (js/with-engine [engine (uglify-js/create-engine)]
      (minify-js engine js options)))
   ([engine js options]
    (if (looks-like-already-minified js)
      js
-     (js/run-script-with-error-handling
-      engine
-      (js-minification-code js (:uglify-js options))
-      (:path options)))))
+     (uglify-js/minify engine js (assoc (:uglify-js options) :path (:path options))))))
 
 (defn minify-js-asset
   [engine asset options]
@@ -81,81 +33,37 @@
 (defn minify-js-assets
   ([assets] (minify-js-assets assets {}))
   ([assets options]
-   (js/with-engine [engine (prepare-uglify-engine)]
-     (doall (map #(minify-js-asset engine % options)
-                 assets)))))
+   (js/with-engine [engine (uglify-js/create-engine)]
+     (mapv #(minify-js-asset engine % options) assets))))
 
 ;; minify CSS
 
-;; TODO:
-;; - oppdag gammel config, og gjør vårt beste for å mappe til ny
-;; - gjør hele clean-css opts tilgjengelig ved å bare sende den videre som json
+(defn get-css-minifier [options]
+  {:engine (clean-css/create-engine)
+   :optimize #'clean-css/minify-css
+   :options (:clean-css options)})
 
-(def default-clean-css-settings
-  {:level 2})
-
-(defn create-legacy-clean-css-settings [options]
-  {:level {1 {:all true
-              :specialComments (:keep-special-comments options "'all'")}
-           2 {:all (:advanced-optimizations options true)}}
-   :format (if (:keep-line-breaks options) "keep-breaks" false)
-   :compatibility (:compatibility options "*")})
-
-(defn is-legacy-clean-css-opts? [options]
-  (seq (select-keys options [:keep-special-comments :advanced-optimizations :keep-line-breaks])))
-
-(defn get-clean-css-settings [options]
-  (-> (let [options (dissoc options :aggressive-merging)]
-        (if (is-legacy-clean-css-opts? options)
-          (create-legacy-clean-css-settings options)
-          (or (not-empty options) default-clean-css-settings)))
-      (assoc :inline false)))
-
-(defn css-minification-code
-  [css options]
-  (str "(function () {
-        var CleanCSS = require('clean-css');
-        var source = '" (escape (normalize-line-endings css)) "';
-        var options = " (json/write-str (get-clean-css-settings options)) ";
-        var minified = new CleanCSS(options).minify(source).styles;
-        return minified;
-}());"))
-
-(def clean-css
-  "The clean-css source code, free of dependencies and runnable in a
-  stripped context"
-  (slurp (io/resource "clean-css.js")))
-
-(defn prepare-clean-css-engine
-  "Minify CSS with the bundled clean-css version"
-  []
-  (let [engine (js/make-engine)]
-    (.eval engine "var window = { XMLHttpRequest: {} };")
-    (.eval engine clean-css)
-    engine))
-
-(defn minify-css
-  ([css] (minify-css css {}))
-  ([css options]
-   (js/with-engine [engine (prepare-clean-css-engine)]
-     (minify-css engine css options)))
-  ([engine css options]
-   (if (looks-like-already-minified css)
-     css
-     (js/run-script-with-error-handling
-      engine
-      (css-minification-code css (:clean-css options))
-      (:path options)))))
+(defn minify-css [optimizer css {:keys [path]}]
+  (if (looks-like-already-minified css)
+    css
+    (let [{:keys [optimize engine options]} optimizer]
+      (try
+        (optimize engine css options)
+        (catch Exception e
+          (throw (ex-info (str "Failed to optimize " path)
+                          {:path path :options options}
+                          e)))))))
 
 (defn minify-css-asset
-  [engine asset options]
+  [optimizer asset]
   (let [#^String path (:path asset)]
     (if (.endsWith path ".css")
-      (update-in asset [:contents] #(minify-css engine % (assoc options :path path)))
+      (update-in asset [:contents] #(minify-css optimizer % {:path path}))
       asset)))
 
 (defn minify-css-assets
   ([assets] (minify-css-assets assets {}))
   ([assets options]
-   (js/with-engine [engine (prepare-clean-css-engine)]
-     (doall (map #(minify-css-asset engine % options) assets)))))
+   (let [optimizer (get-css-minifier options)]
+     (js/with-engine [_engine (:engine optimizer)]
+       (mapv #(minify-css-asset optimizer %) assets)))))

--- a/src/optimus/uglify_js.clj
+++ b/src/optimus/uglify_js.clj
@@ -1,0 +1,48 @@
+(ns optimus.uglify-js
+  (:require [clojure.java.io :as io]
+            [optimus.js :as js]))
+
+(def ^String babel
+  (slurp (io/resource "babel.js")))
+
+(defn js-minification-code
+  [js options]
+  (let [js-code (js/escape (js/normalize-line-endings js))]
+    (str "(function () {"
+         (if (:transpile-es6? options)
+           (str "var jsCode = Babel.transform('" js-code "', { presets: ['env'], sourceType: 'script' }).code;")
+           (str "var jsCode = '" js-code "';"))
+         "var ast = UglifyJS.parse(jsCode);
+          ast.figure_out_scope();
+          var compressor = UglifyJS.Compressor();
+          var compressed = ast.transform(compressor);
+          compressed.figure_out_scope();
+          compressed.compute_char_frequency();"
+         (if (get options :mangle-names true) "compressed.mangle_names();" "")
+         "var stream = UglifyJS.OutputStream();
+          compressed.print(stream);
+          return stream.toString();
+}());")))
+
+(def ^String uglify
+  "The UglifyJS source code, free of dependencies and runnable in a
+  stripped context"
+  (slurp (io/resource "uglify.js")))
+
+(defn create-engine
+  []
+  (let [engine (js/make-engine)]
+    (.eval engine uglify)
+    (.eval engine babel)
+    engine))
+
+(defn minify
+  ([js] (minify js {}))
+  ([js options]
+   (js/with-engine [engine (create-engine)]
+     (minify engine js options)))
+  ([engine js options]
+   (js/run-script-with-error-handling
+    engine
+    (js-minification-code js options)
+    (:path options))))

--- a/test/optimus/clean_css_test.clj
+++ b/test/optimus/clean_css_test.clj
@@ -1,0 +1,75 @@
+(ns optimus.clean-css-test
+  (:require [midje.sweet :refer [fact =>]]
+            [optimus.clean-css :as sut]))
+
+(fact (sut/minify-css "body { color: red; }") => "body{color:red}")
+(fact (sut/minify-css "body {\n    color: red;\n}") => "body{color:red}")
+
+(fact
+ "You can turn off advanced optimizations."
+
+ (sut/minify-css ".one{padding:0}.two{margin:0}.one{margin-bottom:3px}")
+ => ".two{margin:0}.one{padding:0;margin-bottom:3px}"
+
+ (sut/minify-css ".one{padding:0}.two{margin:0}.one{margin-bottom:3px}" {:advanced-optimizations false})
+ => ".one{padding:0}.two{margin:0}.one{margin-bottom:3px}"
+
+ (sut/minify-css ".one{padding:0}.two{margin:0}.one{margin-bottom:3px}" {:level 1})
+ => ".one{padding:0}.two{margin:0}.one{margin-bottom:3px}")
+
+(fact
+ "You can keep line-breaks."
+
+ (sut/minify-css "body{color:red}\nhtml{color:#00f}")
+ => "body{color:red}html{color:#00f}"
+
+ (sut/minify-css "body{color:red}\nhtml{color:#00f}" {:keep-line-breaks true})
+ => "body{color:red}\nhtml{color:#00f}")
+
+(fact
+  "You can control special comments."
+
+  (sut/minify-css "/*! comment */\nbody{color:red}")
+  => "/*! comment */body{color:red}"
+
+  (sut/minify-css "/*! comment */\nbody{color:red}" {:keep-special-comments 0})
+  => "body{color:red}")
+
+(fact
+  "You can control compatibility mode."
+
+  (sut/minify-css "body{margin:0px 0rem}")
+  => "body{margin:0}"
+
+  (sut/minify-css "body{margin:0px 0rem}" {:compatibility "ie7"})
+  => "body{margin:0 0rem}")
+
+(fact
+ "It doesn't mess up percentages after rgb-colors."
+
+ (sut/minify-css "body { background: -webkit-linear-gradient(bottom, rgb(209,209,209) 10%, rgb(250,250,250) 55%);}")
+ => "body{background:-webkit-linear-gradient(bottom,#d1d1d1 10%,#fafafa 55%)}")
+
+(fact
+ "It doesn't mess up variable names."
+
+ (sut/minify-css "body { background: magenta; color: var(--light-magenta); }")
+ => "body{background:#ff00ff;color:var(--light-magenta)}")
+
+(fact
+  "It doesn't mess up media queries."
+  (sut/minify-css "@media screen and (orientation:landscape) {#id{color:red}}")
+  => "@media screen and (orientation:landscape){#id{color:red}}"
+
+  (sut/minify-css "@import url(abc.css) screen and (min-width:7) and (max-width:9);")
+  => "@import url(abc.css) screen and (min-width:7) and (max-width:9);")
+
+(fact
+  "It correctly minifies several rules for the same selector"
+  (sut/minify-css "table,div {border:0} table {margin:0}" {})
+  => "div,table{border:0}table{margin:0}")
+
+(fact
+  "doesn't remove transition property with never features"
+  (sut/minify-css "#menu{transform:translateX(-100%);transition:transform .25s ease-in,overlay .25s allow-discrete,display .25s allow-discrete;overflow-y:scroll}" {})
+  => "#menu{transform:translateX(-100%);transition:transform .25s ease-in,overlay .25s allow-discrete,display .25s allow-discrete;overflow-y:scroll}")

--- a/test/optimus/csso_test.clj
+++ b/test/optimus/csso_test.clj
@@ -1,0 +1,12 @@
+(ns optimus.csso-test
+  (:require [midje.sweet :refer [=> fact]]
+            [optimus.csso :as sut]))
+
+(fact
+  (sut/minify "body { color: red; }\nbody { background: black; }")
+  => "body{color:red;background:#000}")
+
+(fact
+  (sut/minify "body { color: red; }\nbody { background: black; }"
+              {:restructure false})
+  => "body{color:red}body{background:#000}")

--- a/test/optimus/optimizations/minify_test.clj
+++ b/test/optimus/optimizations/minify_test.clj
@@ -55,3 +55,13 @@
                      {:path "styles.css" :contents "#id { margin: 0; }"}])
  => [{:path "code.js" :contents "var a = 2 + 3;"}
      {:path "styles.css" :contents "#id{margin:0}"}])
+
+(fact
+ "It uses clean-css when there are explicit clean-css options"
+ (sut/minify-css-assets [{:path "styles.css" :contents "body {color: red;} body {background: blue;}"}] {:clean-css {}})
+ => [{:path "styles.css", :contents "body{color:red;background:#00f}"}])
+
+(fact
+  "It defaults to using csso when there are explicit clean-css options"
+  (sut/minify-css-assets [{:path "styles.css" :contents "body {color: red;} body {background: blue;}"}] {:csso {:restructure false}})
+  => [{:path "styles.css", :contents "body{color:red}body{background:#00f}"}])

--- a/test/optimus/optimizations/minify_test.clj
+++ b/test/optimus/optimizations/minify_test.clj
@@ -7,59 +7,6 @@
  (sut/minify-js "var hello = 2 + 3;") => "var hello=5;")
 
 (fact
- "Minifies JS with quotes"
- (sut/minify-js "var hello = 'Hey';") => "var hello=\"Hey\";")
-
-(fact
- "Minifies JS with newlines"
- (sut/minify-js "var hello = 'Hey' + \n 'there';") => "var hello=\"Heythere\";")
-
-(fact
- "Minifies JS with nasty regex"
- (sut/minify-js "var rsingleTag = /^<(\\w+)\\s*\\/?>(?:<\\/\\1>|)$/;") => "var rsingleTag=/^<(\\w+)\\s*\\/?>(?:<\\/\\1>|)$/;")
-
-(fact
- "Transpiles lambda notation to valid ES5 when option is enabled"
- (sut/minify-js "const hello = (hey) => { console.info(hey)};" {:uglify-js {:transpile-es6? true}})
- => "var hello=function(o){console.info(o)};")
-
-(fact
- "Does not transpile when option is not enabled"
- (sut/minify-js "const hello = (hey) => { console.info(hey)};")
- => (throws Exception #"Unexpected token"))
-
-(fact
- "Transpiles class definition to valied ES5"
- (sut/minify-js "class Test {}" {:uglify-js {:transpile-es6? true}})
- => "function _typeof(e){\"@babel/helpers - typeof\";return(_typeof=\"function\"==typeof Symbol&&\"symbol\"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&\"function\"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?\"symbol\":typeof e})(e)}function _defineProperties(e,t){for(var r=0;r<t.length;r++){var o=t[r];o.enumerable=o.enumerable||!1,o.configurable=!0,\"value\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o)}}function _createClass(e,t,r){return t&&_defineProperties(e.prototype,t),r&&_defineProperties(e,r),Object.defineProperty(e,\"prototype\",{writable:!1}),e}function _toPropertyKey(e){var t=_toPrimitive(e,\"string\");return\"symbol\"===_typeof(t)?t:String(t)}function _toPrimitive(e,t){if(\"object\"!==_typeof(e)||null===e)return e;var r=e[Symbol.toPrimitive];if(void 0!==r){var o=r.call(e,t||\"default\");if(\"object\"!==_typeof(o))return o;throw new TypeError(\"@@toPrimitive must return a primitive value.\")}return(\"string\"===t?String:Number)(e)}function _classCallCheck(e,t){if(!(e instanceof t))throw new TypeError(\"Cannot call a class as a function\")}var Test=_createClass(function e(){\"use strict\";_classCallCheck(this,e)});")
-
-(fact
- "Transpiles 'let' to valid ES5 and minifies expressions"
- (sut/minify-js "let apekatt = 7+3;" {:uglify-js {:transpile-es6? true}})
- => "var apekatt=10;")
-
-(fact
- "Throws exception on syntax errors"
- (sut/minify-js "var hello =") => (throws Exception #"Unexpected token"))
-
-(fact
- "Mangles names by default"
- (sut/minify-js "var hmm = (function () { var yoyoyo = 2; return yoyoyo; }());")
- => "var hmm=function(){var r=2;return r}();")
-
-(fact
- "Disable name mangling"
- (sut/minify-js "var hmm = (function () { var yoyoyo = 2; return yoyoyo; }());" {:uglify-js {:mangle-names false}})
- => "var hmm=function(){var yoyoyo=2;return yoyoyo}();")
-
-(fact
- "To save some time minifying a lot of files, we can create the
-  uglify.JS context up front, and then reuse that for all the assets."
- (let [eng (sut/prepare-uglify-engine)]
-   (sut/minify-js eng "var hello = 2 + 3;" {}) => "var hello=5;"
-   (sut/minify-js eng "var hello = 3 + 4;" {}) => "var hello=7;"))
-
-(fact
  "It minifies a list of JS assets."
  (sut/minify-js-assets [{:path "code.js" :contents "var a = 2 + 3;"}
                     {:path "more.js" :contents "var b = 4 + 5;"}])
@@ -88,69 +35,12 @@
 
 ;; minify CSS
 
-(fact (sut/minify-css "body { color: red; }") => "body{color:red}")
-(fact (sut/minify-css "body {\n    color: red;\n}") => "body{color:red}")
-
-(comment ;; clean-css doesn't throw exceptions for mangled CSS - see https://github.com/jakubpawlowicz/clean-css/issues/449
-  (fact (sut/minify-css "body {\n    color: red") => (throws Exception "Please check the validity of the CSS block starting from the line #1"))
-
-  (fact
-   "It includes the path in exception."
-   (sut/minify-css-assets [{:path "styles.css" :contents "body {\n    color: red"}])
-   => (throws Exception "Exception in styles.css: Please check the validity of the CSS block starting from the line #1")))
-
-(fact
- "You can turn off advanced optimizations."
-
- (sut/minify-css ".one{padding:0}.two{margin:0}.one{margin-bottom:3px}")
- => ".two{margin:0}.one{padding:0;margin-bottom:3px}"
-
- (sut/minify-css ".one{padding:0}.two{margin:0}.one{margin-bottom:3px}" {:clean-css {:advanced-optimizations false}})
- => ".one{padding:0}.two{margin:0}.one{margin-bottom:3px}"
-
- (sut/minify-css ".one{padding:0}.two{margin:0}.one{margin-bottom:3px}" {:clean-css {:level 1}})
- => ".one{padding:0}.two{margin:0}.one{margin-bottom:3px}")
-
-(fact
- "You can keep line-breaks."
-
- (sut/minify-css "body{color:red}\nhtml{color:#00f}") => "body{color:red}html{color:#00f}"
- (sut/minify-css "body{color:red}\nhtml{color:#00f}" {:clean-css {:keep-line-breaks true}}) => "body{color:red}\nhtml{color:#00f}")
-
-(fact
- "You can control special comments."
-
- (sut/minify-css "/*! comment */\nbody{color:red}") => "/*! comment */body{color:red}"
- (sut/minify-css "/*! comment */\nbody{color:red}" {:clean-css {:keep-special-comments 0}}) => "body{color:red}")
-
-(fact
- "You can control compatibility mode."
-
- (sut/minify-css "body{margin:0px 0rem}") => "body{margin:0}"
- (sut/minify-css "body{margin:0px 0rem}" {:clean-css {:compatibility "ie7"}}) => "body{margin:0 0rem}")
-
-(fact
- "It doesn't mess up percentages after rgb-colors."
-
- (sut/minify-css "body { background: -webkit-linear-gradient(bottom, rgb(209,209,209) 10%, rgb(250,250,250) 55%);}")
- => "body{background:-webkit-linear-gradient(bottom,#d1d1d1 10%,#fafafa 55%)}")
-
-(fact
- "It doesn't mess up variable names."
-
- (sut/minify-css "body { background: magenta; color: var(--light-magenta); }")
- => "body{background:#ff00ff;color:var(--light-magenta)}")
-
 (fact
  "It skips minification of css files with very long one-liners. It's a decent
   heuristic that it's already minified."
- (let [css (str "/* comment */\nbody {" (apply str (repeat 500 "color:red;")) "}")]
-   (sut/minify-css css) => css))
-
-(fact
- "It doesn't mess up media queries."
- (sut/minify-css "@media screen and (orientation:landscape) {#id{color:red}}") => "@media screen and (orientation:landscape){#id{color:red}}"
- (sut/minify-css "@import url(abc.css) screen and (min-width:7) and (max-width:9);") => "@import url(abc.css) screen and (min-width:7) and (max-width:9);")
+ (let [css {:path "styles.css"
+            :contents (str "/* comment */\nbody {" (apply str (repeat 500 "color:red;")) "}")}]
+   (sut/minify-css-assets [css]) => [css]))
 
 (fact
  "It minifies a list of CSS assets."
@@ -165,14 +55,3 @@
                      {:path "styles.css" :contents "#id { margin: 0; }"}])
  => [{:path "code.js" :contents "var a = 2 + 3;"}
      {:path "styles.css" :contents "#id{margin:0}"}])
-
-(fact
-  "It correctly minifies several rules for the same selector"
-  (sut/minify-css (sut/prepare-clean-css-engine) "table,div {border:0} table {margin:0}" {}) => "div,table{border:0}table{margin:0}")
-
-(fact
- "doesn't remove transition property with never features"
- (sut/minify-css (sut/prepare-clean-css-engine)
-                 "#menu{transform:translateX(-100%);transition:transform .25s ease-in,overlay .25s allow-discrete,display .25s allow-discrete;overflow-y:scroll}"
-                 {})
- => "#menu{transform:translateX(-100%);transition:transform .25s ease-in,overlay .25s allow-discrete,display .25s allow-discrete;overflow-y:scroll}")

--- a/test/optimus/uglify_js_test.clj
+++ b/test/optimus/uglify_js_test.clj
@@ -1,0 +1,53 @@
+(ns optimus.uglify-js-test
+  (:require [midje.sweet :refer [fact => throws]]
+            [optimus.uglify-js :as sut]))
+
+(fact
+  "Minifies JS"
+  (sut/minify "var hello = 2 + 3;") => "var hello=5;")
+
+(fact
+  "Minifies JS with quotes"
+  (sut/minify "var hello = 'Hey';") => "var hello=\"Hey\";")
+
+(fact
+  "Minifies JS with newlines"
+  (sut/minify "var hello = 'Hey' + \n 'there';") => "var hello=\"Heythere\";")
+
+(fact
+  "Minifies JS with nasty regex"
+  (sut/minify "var rsingleTag = /^<(\\w+)\\s*\\/?>(?:<\\/\\1>|)$/;") => "var rsingleTag=/^<(\\w+)\\s*\\/?>(?:<\\/\\1>|)$/;")
+
+(fact
+  "Transpiles lambda notation to valid ES5 when option is enabled"
+  (sut/minify "const hello = (hey) => { console.info(hey)};" {:transpile-es6? true})
+  => "var hello=function(o){console.info(o)};")
+
+(fact
+  "Does not transpile when option is not enabled"
+  (sut/minify "const hello = (hey) => { console.info(hey)};")
+  => (throws Exception #"Unexpected token"))
+
+(fact
+  "Transpiles class definition to valied ES5"
+  (sut/minify "class Test {}" {:transpile-es6? true})
+  => "function _typeof(e){\"@babel/helpers - typeof\";return(_typeof=\"function\"==typeof Symbol&&\"symbol\"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&\"function\"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?\"symbol\":typeof e})(e)}function _defineProperties(e,t){for(var r=0;r<t.length;r++){var o=t[r];o.enumerable=o.enumerable||!1,o.configurable=!0,\"value\"in o&&(o.writable=!0),Object.defineProperty(e,_toPropertyKey(o.key),o)}}function _createClass(e,t,r){return t&&_defineProperties(e.prototype,t),r&&_defineProperties(e,r),Object.defineProperty(e,\"prototype\",{writable:!1}),e}function _toPropertyKey(e){var t=_toPrimitive(e,\"string\");return\"symbol\"===_typeof(t)?t:String(t)}function _toPrimitive(e,t){if(\"object\"!==_typeof(e)||null===e)return e;var r=e[Symbol.toPrimitive];if(void 0!==r){var o=r.call(e,t||\"default\");if(\"object\"!==_typeof(o))return o;throw new TypeError(\"@@toPrimitive must return a primitive value.\")}return(\"string\"===t?String:Number)(e)}function _classCallCheck(e,t){if(!(e instanceof t))throw new TypeError(\"Cannot call a class as a function\")}var Test=_createClass(function e(){\"use strict\";_classCallCheck(this,e)});")
+
+(fact
+  "Transpiles 'let' to valid ES5 and minifies expressions"
+  (sut/minify "let apekatt = 7+3;" {:transpile-es6? true})
+  => "var apekatt=10;")
+
+(fact
+  "Throws exception on syntax errors"
+  (sut/minify "var hello =") => (throws Exception #"Unexpected token"))
+
+(fact
+  "Mangles names by default"
+  (sut/minify "var hmm = (function () { var yoyoyo = 2; return yoyoyo; }());")
+  => "var hmm=function(){var r=2;return r}();")
+
+(fact
+  "Disable name mangling"
+  (sut/minify "var hmm = (function () { var yoyoyo = 2; return yoyoyo; }());" {:mangle-names false})
+  => "var hmm=function(){var yoyoyo=2;return yoyoyo}();")


### PR DESCRIPTION
This PR restructures the minify namespace and provides both clean-css and csso as alternatives for CSS minification. csso is newer and more resilient with modern CSS syntax, and is used as the default unless Optimus receives specific clean-css options.