### PR TITLE
Add new default CSS optimizer ph-css

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,7 @@
                  [pathetic "0.5.1"]
                  [org.graalvm.js/js "19.3.0"]
                  [org.graalvm.js/js-scriptengine "19.3.0"]
+                 [com.helger/ph-css "8.2.0"]
                  [environ "1.1.0"]
                  [com.nextjournal/beholder "1.0.2"]
                  [potemkin "0.4.5"]

--- a/src/optimus/optimizations/minify.clj
+++ b/src/optimus/optimizations/minify.clj
@@ -3,6 +3,7 @@
             [optimus.clean-css :as clean-css]
             [optimus.csso :as csso]
             [optimus.js :as js]
+            [optimus.ph-css :as ph-css]
             [optimus.uglify-js :as uglify-js]))
 
 (defn looks-like-already-minified
@@ -40,20 +41,26 @@
 ;; minify CSS
 
 (defn get-css-minifier [options]
-  (if-let [clean-css (:clean-css options)]
-    {:engine (clean-css/create-engine)
-     :optimize #'clean-css/minify-css
-     :options clean-css}
-    {:engine (csso/create-engine)
-     :optimize #'csso/minify
-     :options (:csso options)}))
+  (or
+   (when-let [clean-css (:clean-css options)]
+     {:engine (clean-css/create-engine)
+      :optimize #'clean-css/minify-css
+      :options clean-css})
+   (when-let [csso (:csso options)]
+     {:engine (csso/create-engine)
+      :optimize #'csso/minify
+      :options csso})
+   {:optimize #'ph-css/minify
+    :options (:ph-css options)}))
 
 (defn minify-css [optimizer css {:keys [path]}]
   (if (looks-like-already-minified css)
     css
     (let [{:keys [optimize engine options]} optimizer]
       (try
-        (optimize engine css options)
+        (if engine
+          (optimize engine css options)
+          (optimize css options))
         (catch Exception e
           (throw (ex-info (str "Failed to optimize " path)
                           {:path path :options options}
@@ -70,5 +77,7 @@
   ([assets] (minify-css-assets assets {}))
   ([assets options]
    (let [optimizer (get-css-minifier options)]
-     (js/with-engine [_engine (:engine optimizer)]
+     (if (:engine optimizer)
+       (js/with-engine [_engine (:engine optimizer)]
+         (mapv #(minify-css-asset optimizer %) assets))
        (mapv #(minify-css-asset optimizer %) assets)))))

--- a/src/optimus/optimizations/minify.clj
+++ b/src/optimus/optimizations/minify.clj
@@ -40,7 +40,7 @@
 ;; minify CSS
 
 (defn get-css-minifier [options]
-  (let [clean-css (:clean-css options)]
+  (if-let [clean-css (:clean-css options)]
     {:engine (clean-css/create-engine)
      :optimize #'clean-css/minify-css
      :options clean-css}

--- a/src/optimus/ph_css.clj
+++ b/src/optimus/ph_css.clj
@@ -1,0 +1,65 @@
+(ns optimus.ph-css
+  (:import (com.helger.base.system ENewLineMode)
+           (com.helger.css.reader CSSReader CSSReaderSettings)
+           (com.helger.css.writer CSSWriter CSSWriterSettings)
+           (java.nio.charset StandardCharsets)))
+
+(def new-line-modes
+  {:default ENewLineMode/DEFAULT
+   :mac ENewLineMode/MAC
+   :uniw ENewLineMode/UNIX
+   :windows ENewLineMode/WINDOWS})
+
+(defn options->writer-settings [options]
+  (let [new-line-mode (new-line-modes (:new-line-mode options))]
+    (cond-> (-> (CSSWriterSettings.)
+                (.setOptimizedOutput (:optimized-output? options true))
+                (.setRemoveUnnecessaryCode (:remove-unnecessary-code? options true)))
+      new-line-mode
+      (.setNewLineMode new-line-mode)
+
+      (number? (:indent options))
+      (.setIndent (repeat (:indent options) " "))
+
+      (contains? options :quote-urls?)
+      (.setQuoteURLs (:quote-urls? options))
+
+      (contains? options :write-namespace-rules?)
+      (.setWriteNamespaceRules (:write-namespace-rules? options))
+
+      (contains? options :write-nested-declarations?)
+      (.setWriteNestedDeclarations (:write-nested-declarations? options))
+
+      (contains? options :write-font-face-rules?)
+      (.setWriteFontFaceRules (:write-font-face-rules? options))
+
+      (contains? options :write-key-frames-rules?)
+      (.setWriteKeyframesRules (:write-key-frames-rules? options))
+
+      (contains? options :write-layer-rules?)
+      (.setWriteLayerRules (:write-layer-rules? options))
+
+      (contains? options :write-media-rules?)
+      (.setWriteMediaRules (:write-media-rules? options))
+
+      (contains? options :write-page-rules?)
+      (.setWritePageRules (:write-page-rules? options))
+
+      (contains? options :write-viewport-rules?)
+      (.setWriteViewportRules (:write-viewport-rules? options))
+
+      (contains? options :write-supports-rules?)
+      (.setWriteSupportsRules (:write-supports-rules? options))
+
+      (contains? options :write-property-rules?)
+      (.setWritePropertyRules (:write-property-rules? options))
+
+      (contains? options :write-unknown-rules?)
+      (.setWriteUnknownRules (:write-unknown-rules? options)))))
+
+(defn minify [^String css & [options]]
+  (some->> (CSSReader/readFromStringReader
+            css
+            (-> (CSSReaderSettings.)
+                (.setFallbackCharset StandardCharsets/UTF_8)))
+           (.getCSSAsString (CSSWriter. (options->writer-settings options)))))

--- a/test/optimus/optimizations/minify_test.clj
+++ b/test/optimus/optimizations/minify_test.clj
@@ -57,11 +57,16 @@
      {:path "styles.css" :contents "#id{margin:0}"}])
 
 (fact
- "It uses clean-css when there are explicit clean-css options"
- (sut/minify-css-assets [{:path "styles.css" :contents "body {color: red;} body {background: blue;}"}] {:clean-css {}})
- => [{:path "styles.css", :contents "body{color:red;background:#00f}"}])
+  "It uses clean-css when there are explicit clean-css options"
+  (sut/minify-css-assets [{:path "styles.css" :contents "body {color: red;} body {background: blue;}"}] {:clean-css {}})
+  => [{:path "styles.css", :contents "body{color:red;background:#00f}"}])
 
 (fact
-  "It defaults to using csso when there are explicit clean-css options"
+  "It uses csso when there are explicit csso options"
   (sut/minify-css-assets [{:path "styles.css" :contents "body {color: red;} body {background: blue;}"}] {:csso {:restructure false}})
   => [{:path "styles.css", :contents "body{color:red}body{background:#00f}"}])
+
+(fact
+  "It defaults to ph-css which can handle modern CSS syntax"
+  (sut/minify-css-assets [{:path "styles.css" :contents ".prose { :where(h1) { font-weight: 800; } } "}] {})
+  => [{:path "styles.css", :contents ".prose{:where(h1){font-weight:800}}"}])

--- a/test/optimus/ph_css_test.clj
+++ b/test/optimus/ph_css_test.clj
@@ -1,0 +1,11 @@
+(ns optimus.ph-css-test
+  (:require [midje.sweet :refer [=> fact]]
+            [optimus.ph-css :as sut]))
+
+(fact
+  (sut/minify "body { color: red; }\nbody { background: black; }")
+  => "body{color:red}body{background:black}")
+
+(fact
+  (sut/minify ".prose { :where(h1) { font-weight: 800; } } ")
+  => ".prose{:where(h1){font-weight:800}}")


### PR DESCRIPTION
This optimizer has better CSS syntax support than both csso and clean-css, and is written in Java, which means there's no need for GraalVM and JavaScript engines.